### PR TITLE
Fix android auto readme

### DIFF
--- a/android-auto-app/README.md
+++ b/android-auto-app/README.md
@@ -8,8 +8,6 @@ The android-auto-app showcases the minimum integration needed to support the and
 
 ## Installation
 
-### [android-auto-app](android-auto-app)
-
 1. Change "Configuration" of "android-auto-app". "Launch Options - Launch" should be "Nothing"
 1. Update or create the "mapbox_access_token.xml" under "android-auto-app/src/main/res/values" and put below
    <?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
I was double checking a few links from this PR https://github.com/mapbox/mapbox-navigation-android-examples/pull/37

Specifically the link in the installation section https://github.com/mapbox/mapbox-navigation-android-examples/tree/main/android-auto-app#installation

Leads here
https://github.com/mapbox/mapbox-navigation-android-examples/blob/main/android-auto-app/android-auto-app

Which is broken. 

Deleting this because it doesn't make sense to link to the current page