### PR TITLE
Update android auto

### DIFF
--- a/android-auto-app/src/main/java/com/mapbox/navigation/examples/androidauto/ExampleApplication.kt
+++ b/android-auto-app/src/main/java/com/mapbox/navigation/examples/androidauto/ExampleApplication.kt
@@ -1,15 +1,9 @@
 package com.mapbox.navigation.examples.androidauto
 
 import android.app.Application
-import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.LifecycleOwner
 import com.mapbox.androidauto.MapboxCarApp
-import com.mapbox.androidauto.logAndroidAuto
-import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.base.options.NavigationOptions
-import com.mapbox.navigation.core.MapboxNavigation
-import com.mapbox.navigation.core.MapboxNavigationProvider
-import com.mapbox.navigation.core.replay.route.ReplayProgressObserver
+import com.mapbox.navigation.lifecycle.MapboxNavigationApp
 import com.mapbox.search.MapboxSearchSdk
 
 class ExampleApplication : Application() {
@@ -20,7 +14,15 @@ class ExampleApplication : Application() {
         val searchLocationProvider = SearchLocationProvider(applicationContext)
         initializeSearchSDK(searchLocationProvider)
 
-        MapboxCarApp.carAppLifecycleOwner.lifecycle.addObserver(mapboxNavigationLifecycle)
+        // Setup MapboxNavigation
+        MapboxNavigationApp.setup(this) {
+            NavigationOptions.Builder(applicationContext)
+                .accessToken(getString(R.string.mapbox_access_token))
+                .build()
+        }
+        MapboxNavigationApp.registerObserver(ReplayNavigationObserver())
+
+        // Setup android auto
         MapboxCarApp.setup(this, ExampleCarInitializer())
     }
 
@@ -30,30 +32,5 @@ class ExampleApplication : Application() {
             getString(R.string.mapbox_access_token),
             searchLocationProvider
         )
-    }
-
-    private val mapboxNavigationLifecycle = object : DefaultLifecycleObserver {
-
-        override fun onStart(owner: LifecycleOwner) {
-            logAndroidAuto("OneTapApplication onStart")
-            val navigationOptions = NavigationOptions.Builder(applicationContext)
-                .accessToken(getString(R.string.mapbox_access_token))
-                .build()
-            MapboxNavigationProvider.create(navigationOptions)
-                .withDebugSimulatorEnabled()
-        }
-
-        override fun onStop(owner: LifecycleOwner) {
-            logAndroidAuto("OneTapApplication onStop")
-            MapboxNavigationProvider.destroy()
-        }
-    }
-
-    @OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
-    private fun MapboxNavigation.withDebugSimulatorEnabled() = apply {
-        if (ExampleCarInitializer.ENABLE_REPLAY) {
-            registerRouteProgressObserver(ReplayProgressObserver(mapboxReplayer))
-            registerRoutesObserver(ReplayRoutesObserver(mapboxReplayer, applicationContext))
-        }
     }
 }

--- a/android-auto-app/src/main/java/com/mapbox/navigation/examples/androidauto/ReplayNavigationObserver.kt
+++ b/android-auto-app/src/main/java/com/mapbox/navigation/examples/androidauto/ReplayNavigationObserver.kt
@@ -1,0 +1,28 @@
+package com.mapbox.navigation.examples.androidauto
+
+import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.replay.route.ReplayProgressObserver
+import com.mapbox.navigation.lifecycle.MapboxNavigationObserver
+
+@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
+class ReplayNavigationObserver : MapboxNavigationObserver {
+    private lateinit var replayProgressObserver: ReplayProgressObserver
+    private lateinit var replayRoutesObserver: ReplayRoutesObserver
+
+    override fun onAttached(mapboxNavigation: MapboxNavigation) {
+        if (ExampleCarInitializer.ENABLE_REPLAY) {
+            val mapboxReplayer = mapboxNavigation.mapboxReplayer
+            val applicationContext = mapboxNavigation.navigationOptions.applicationContext
+            replayProgressObserver = ReplayProgressObserver(mapboxReplayer)
+            replayRoutesObserver = ReplayRoutesObserver(mapboxReplayer, applicationContext)
+            mapboxNavigation.registerRouteProgressObserver(replayProgressObserver)
+            mapboxNavigation.registerRoutesObserver(replayRoutesObserver)
+        }
+    }
+
+    override fun onDetached(mapboxNavigation: MapboxNavigation?) {
+        mapboxNavigation?.unregisterRouteProgressObserver(replayProgressObserver)
+        mapboxNavigation?.unregisterRoutesObserver(replayRoutesObserver)
+    }
+}

--- a/android-auto/build.gradle.kts
+++ b/android-auto/build.gradle.kts
@@ -21,7 +21,7 @@ android {
 }
 
 dependencies {
-    api("com.mapbox.navigation:android:2.1.0-beta.1")
+    api("com.mapbox.navigation:android:2.1.0-rc.1")
     api("com.mapbox.search:mapbox-search-android:1.0.0-beta.22")
     implementation("androidx.appcompat:appcompat:1.3.1")
     implementation("androidx.car.app:app:1.0.0")

--- a/android-auto/src/main/java/com/mapbox/androidauto/CarAppServicesProvider.kt
+++ b/android-auto/src/main/java/com/mapbox/androidauto/CarAppServicesProvider.kt
@@ -1,10 +1,11 @@
 package com.mapbox.androidauto
 
+import com.mapbox.androidauto.navigation.audioguidance.MapboxAudioGuidance
 import com.mapbox.androidauto.navigation.audioguidance.impl.MapboxAudioGuidanceImpl
 import com.mapbox.androidauto.navigation.audioguidance.impl.MapboxAudioGuidanceServicesImpl
-import com.mapbox.androidauto.navigation.audioguidance.MapboxAudioGuidance
 import com.mapbox.androidauto.navigation.location.CarAppLocation
 import com.mapbox.androidauto.navigation.location.impl.CarAppLocationImpl
+import com.mapbox.navigation.lifecycle.MapboxNavigationApp
 
 /**
  * The Mapbox services available from android auto for maps, search, and navigation.
@@ -22,7 +23,7 @@ class CarAppServicesProviderImpl : CarAppServicesProvider {
             MapboxAudioGuidanceServicesImpl(),
             MapboxCarApp.carAppDataStore,
             MapboxCarApp.carAppConfig
-        ).also { it.setup(MapboxCarApp.carAppLifecycleOwner) }
+        ).also { it.setup(MapboxNavigationApp.lifecycleOwner) }
     }
     private val location: CarAppLocation by lazy { CarAppLocationImpl() }
 

--- a/android-auto/src/main/java/com/mapbox/androidauto/MapboxCarOptions.kt
+++ b/android-auto/src/main/java/com/mapbox/androidauto/MapboxCarOptions.kt
@@ -61,10 +61,10 @@ class MapboxCarOptions private constructor(
      */
     override fun toString(): String {
         return "MapboxCarOptions(mapInitOptions='$mapInitOptions'," +
-                " mapDayStyle='$mapDayStyle'," +
-                " mapNightStyle=$mapNightStyle," +
-                " replayEnabled=$replayEnabled" +
-                ")"
+            " mapDayStyle='$mapDayStyle'," +
+            " mapNightStyle=$mapNightStyle," +
+            " replayEnabled=$replayEnabled" +
+            ")"
     }
 
     /**

--- a/android-auto/src/main/java/com/mapbox/androidauto/car/map/MapboxCarMap.kt
+++ b/android-auto/src/main/java/com/mapbox/androidauto/car/map/MapboxCarMap.kt
@@ -47,7 +47,7 @@ class MapboxCarMap internal constructor(
         carMapSurfaceSession.unregisterObserver(mapboxCarMapObserver)
     }
 
-    fun clearListeners() {
+    fun clearObservers() {
         carMapSurfaceSession.clearObservers()
     }
 

--- a/android-auto/src/main/java/com/mapbox/androidauto/car/map/MapboxCarMapSurface.kt
+++ b/android-auto/src/main/java/com/mapbox/androidauto/car/map/MapboxCarMapSurface.kt
@@ -18,9 +18,9 @@ class MapboxCarMapSurface internal constructor(
 ) {
     override fun toString(): String {
         return "MapboxCarMapSurface(carContext=$carContext," +
-                " mapSurface=$mapSurface," +
-                " surfaceContainer=$surfaceContainer," +
-                " style=$style" +
-                ")"
+            " mapSurface=$mapSurface," +
+            " surfaceContainer=$surfaceContainer," +
+            " style=$style" +
+            ")"
     }
 }

--- a/android-auto/src/main/java/com/mapbox/androidauto/car/map/impl/CarMapLifecycleObserver.kt
+++ b/android-auto/src/main/java/com/mapbox/androidauto/car/map/impl/CarMapLifecycleObserver.kt
@@ -69,19 +69,23 @@ internal class CarMapLifecycleObserver internal constructor(
             val mapSurface = MapSurface(carContext, it, mapInitOptions)
             mapSurface.onStart()
             mapSurface.surfaceCreated()
-            mapSurface.getMapboxMap().loadStyleUri(mapStyleUri, onStyleLoaded = { style ->
-                logAndroidAuto("CarMapSurfaceLifecycle styleAvailable")
-                mapSurface.surfaceChanged(surfaceContainer.width, surfaceContainer.height)
-                val carMapSurface = MapboxCarMapSurface(carContext, mapSurface, surfaceContainer, style)
-                carMapSurfaceSession.carMapSurfaceAvailable(carMapSurface)
-            }, onMapLoadErrorListener = object : OnMapLoadErrorListener {
-                override fun onMapLoadError(eventData: MapLoadingErrorEventData) {
-                    logAndroidAuto(
-                        "CarMapSurfaceLifecycle updateMapStyle onMapLoadError " +
+            mapSurface.getMapboxMap().loadStyleUri(
+                mapStyleUri,
+                onStyleLoaded = { style ->
+                    logAndroidAuto("CarMapSurfaceLifecycle styleAvailable")
+                    mapSurface.surfaceChanged(surfaceContainer.width, surfaceContainer.height)
+                    val carMapSurface = MapboxCarMapSurface(carContext, mapSurface, surfaceContainer, style)
+                    carMapSurfaceSession.carMapSurfaceAvailable(carMapSurface)
+                },
+                onMapLoadErrorListener = object : OnMapLoadErrorListener {
+                    override fun onMapLoadError(eventData: MapLoadingErrorEventData) {
+                        logAndroidAuto(
+                            "CarMapSurfaceLifecycle updateMapStyle onMapLoadError " +
                                 "${eventData.type} ${eventData.message}"
-                    )
+                        )
+                    }
                 }
-            })
+            )
         }
     }
 
@@ -109,22 +113,25 @@ internal class CarMapLifecycleObserver internal constructor(
         logAndroidAuto("CarMapSurfaceLifecycle updateMapStyle $mapStyle")
         val previousCarMapSurface = carMapSurfaceSession.mapboxCarMapSurface
         val mapSurface = previousCarMapSurface?.mapSurface
-        mapSurface?.getMapboxMap()?.loadStyleUri(mapStyle, onStyleLoaded = { style ->
-            logAndroidAuto("CarMapSurfaceLifecycle updateMapStyle styleAvailable")
-            val carMapSurface = MapboxCarMapSurface(
-                carContext,
-                mapSurface,
-                previousCarMapSurface.surfaceContainer,
-                style
-            )
-            carMapSurfaceSession.carMapSurfaceAvailable(carMapSurface)
-        }, onMapLoadErrorListener = object : OnMapLoadErrorListener {
-            override fun onMapLoadError(eventData: MapLoadingErrorEventData) {
-                logAndroidAuto(
-                    "CarMapSurfaceLifecycle updateMapStyle onMapLoadError " +
-                            "${eventData.type} ${eventData.message}"
+        mapSurface?.getMapboxMap()?.loadStyleUri(
+            mapStyle,
+            onStyleLoaded = { style ->
+                logAndroidAuto("CarMapSurfaceLifecycle updateMapStyle styleAvailable")
+                val carMapSurface = MapboxCarMapSurface(
+                    carContext,
+                    mapSurface,
+                    previousCarMapSurface.surfaceContainer,
+                    style,
                 )
+                carMapSurfaceSession.carMapSurfaceAvailable(carMapSurface)
+            },
+            onMapLoadErrorListener = object : OnMapLoadErrorListener {
+                override fun onMapLoadError(eventData: MapLoadingErrorEventData) {
+                    logAndroidAuto(
+                        "CarMapSurfaceLifecycle updateMapStyle onMapLoadError ${eventData.type} ${eventData.message}",
+                    )
+                }
             }
-        })
+        )
     }
 }

--- a/android-auto/src/main/java/com/mapbox/androidauto/car/map/widgets/ImageOverlayHost.kt
+++ b/android-auto/src/main/java/com/mapbox/androidauto/car/map/widgets/ImageOverlayHost.kt
@@ -381,7 +381,7 @@ open class ImageOverlayHost(
         vTexCoord = aCoordinate;
         gl_Position =  uScreen * uTranslate  * uRotation * vec4(aPosition, 0.0, 1.0);
       }
-    """.trimIndent()
+        """.trimIndent()
 
         private val FRAGMENT_SHADER_CODE = """
       precision mediump float;
@@ -390,7 +390,7 @@ open class ImageOverlayHost(
       void main() {
         gl_FragColor = texture2D(vTexture, vTexCoord);
       }
-    """.trimIndent()
+        """.trimIndent()
 
         private fun loadShader(type: Int, shaderCode: String): Int {
             // create a vertex shader type (GLES20.GL_VERTEX_SHADER)

--- a/android-auto/src/main/java/com/mapbox/androidauto/car/map/widgets/WidgetPosition.kt
+++ b/android-auto/src/main/java/com/mapbox/androidauto/car/map/widgets/WidgetPosition.kt
@@ -4,18 +4,22 @@ package com.mapbox.androidauto.car.map.widgets
  * Gravity that the widget is aligned to the map.
  */
 enum class WidgetPosition {
+
     /**
      * The widget is aligned to the top-left of the map.
      */
     TOP_LEFT,
+
     /**
      * The widget is aligned to the top-right of the map.
      */
     TOP_RIGHT,
+
     /**
      * The widget is aligned to the bottom-left of the map.
      */
     BOTTOM_LEFT,
+
     /**
      * The widget is aligned to the bottom-right of the map.
      */

--- a/android-auto/src/main/java/com/mapbox/androidauto/car/map/widgets/compass/CompassWidget.kt
+++ b/android-auto/src/main/java/com/mapbox/androidauto/car/map/widgets/compass/CompassWidget.kt
@@ -40,7 +40,8 @@ class CompassWidget(
         BitmapFactory.decodeResource(
             context.resources,
             R.drawable.mapbox_compass_icon
-        ), widgetPosition, Margin(marginLeft, marginTop, marginRight, marginBottom)
+        ),
+        widgetPosition, Margin(marginLeft, marginTop, marginRight, marginBottom),
     )
 
     /**

--- a/android-auto/src/main/java/com/mapbox/androidauto/car/map/widgets/logo/LogoWidget.kt
+++ b/android-auto/src/main/java/com/mapbox/androidauto/car/map/widgets/logo/LogoWidget.kt
@@ -41,7 +41,8 @@ class LogoWidget(
             BitmapFactory.decodeResource(
                 context.resources,
                 R.drawable.mapbox_logo_icon
-            ), widgetPosition, Margin(marginLeft, marginTop, marginRight, marginBottom)
+            ),
+            widgetPosition, Margin(marginLeft, marginTop, marginRight, marginBottom),
         )
     }
 

--- a/android-auto/src/main/java/com/mapbox/androidauto/car/navigation/maneuver/CarManeuverIconOptions.kt
+++ b/android-auto/src/main/java/com/mapbox/androidauto/car/navigation/maneuver/CarManeuverIconOptions.kt
@@ -56,10 +56,10 @@ class CarManeuverIconOptions private constructor(
      */
     override fun toString(): String {
         return "CarManeuverIconOptions(" +
-                "context=$context, " +
-                "background=$background, " +
-                "styleRes=$styleRes" +
-                ")"
+            "context=$context, " +
+            "background=$background, " +
+            "styleRes=$styleRes" +
+            ")"
     }
 
     /**
@@ -72,6 +72,7 @@ class CarManeuverIconOptions private constructor(
     ) {
         @ColorInt
         private var background: Int? = null
+
         @StyleRes
         private var styleRes: Int? = null
 

--- a/android-auto/src/main/java/com/mapbox/androidauto/car/navigation/maneuver/CarManeuverIconRenderer.kt
+++ b/android-auto/src/main/java/com/mapbox/androidauto/car/navigation/maneuver/CarManeuverIconRenderer.kt
@@ -30,8 +30,7 @@ class CarManeuverIconRenderer(
         ).onError {
             logAndroidAutoFailure("CarManeuverIconRenderer renderManeuverIcon error ${it.errorMessage}")
         }.value
-        return ifNonNull(maneuverTurnIcon?.icon, maneuverTurnIcon?.shouldFlipIcon) {
-                turnIconRes, shouldFlip ->
+        return ifNonNull(maneuverTurnIcon?.icon, maneuverTurnIcon?.shouldFlipIcon) { turnIconRes, shouldFlip ->
             CarIcon.Builder(
                 IconCompat.createWithBitmap(renderBitmap(turnIconRes, shouldFlip))
             ).build()

--- a/android-auto/src/main/java/com/mapbox/androidauto/car/navigation/roadlabel/RoadLabelSurfaceLayer.kt
+++ b/android-auto/src/main/java/com/mapbox/androidauto/car/navigation/roadlabel/RoadLabelSurfaceLayer.kt
@@ -32,6 +32,14 @@ class RoadLabelSurfaceLayer(
     private val roadLabelRenderer = RoadLabelRenderer()
     private val carTextLayerHost = CarTextLayerHost()
 
+    private val roadNameObserver = object : RoadNameObserver(mapboxNavigation) {
+
+        override fun onRoadUpdate(currentRoadName: RoadName?) {
+            val bitmap = roadLabelRenderer.render(currentRoadName?.name, roadLabelOptions())
+            carTextLayerHost.offerBitmap(bitmap)
+        }
+    }
+
     override fun children() = listOf(carTextLayerHost.mapScene)
 
     @ExperimentalPreviewMapboxNavigationAPI
@@ -67,16 +75,6 @@ class RoadLabelSurfaceLayer(
         mapboxCarMapSurface?.style?.removeStyleLayer(CAR_NAVIGATION_VIEW_LAYER_ID)
         mapboxNavigation.unregisterEHorizonObserver(roadNameObserver)
         super.detached(mapboxCarMapSurface)
-    }
-
-    private val roadNameObserver = object : RoadNameObserver(mapboxNavigation) {
-        override fun onRoadUpdate(currentRoadName: RoadName?) {
-            val bitmap = roadLabelRenderer.render(
-                currentRoadName?.name,
-                roadLabelOptions()
-            )
-            carTextLayerHost.offerBitmap(bitmap)
-        }
     }
 
     private fun roadLabelOptions(): RoadLabelOptions =

--- a/android-auto/src/main/java/com/mapbox/androidauto/car/navigation/speedlimit/CarSpeedLimitRenderer.kt
+++ b/android-auto/src/main/java/com/mapbox/androidauto/car/navigation/speedlimit/CarSpeedLimitRenderer.kt
@@ -29,6 +29,18 @@ class CarSpeedLimitRenderer(
         MapboxSpeedLimitApi(speedLimitFormatter)
     }
 
+    private val locationObserver = object : LocationObserver {
+
+        override fun onNewLocationMatcherResult(locationMatcherResult: LocationMatcherResult) {
+            val value = speedLimitApi.updateSpeedLimit(locationMatcherResult.speedLimit)
+            speedLimitWidget.update(value)
+        }
+
+        override fun onNewRawLocation(rawLocation: Location) {
+            // no op
+        }
+    }
+
     override fun loaded(mapboxCarMapSurface: MapboxCarMapSurface) {
         logAndroidAuto("CarSpeedLimitRenderer carMapSurface loaded")
         mapboxCarMapSurface.style.addPersistentStyleCustomLayer(
@@ -44,16 +56,5 @@ class CarSpeedLimitRenderer(
         MapboxNavigationProvider.retrieve().unregisterLocationObserver(locationObserver)
         mapboxCarMapSurface?.style?.removeStyleLayer(SpeedLimitWidget.SPEED_LIMIT_WIDGET_LAYER_ID)
         speedLimitWidget.clear()
-    }
-
-    private val locationObserver = object : LocationObserver {
-        override fun onNewLocationMatcherResult(locationMatcherResult: LocationMatcherResult) {
-            val value = speedLimitApi.updateSpeedLimit(locationMatcherResult.speedLimit)
-            speedLimitWidget.update(value)
-        }
-
-        override fun onNewRawLocation(rawLocation: Location) {
-            // no op
-        }
     }
 }

--- a/android-auto/src/main/java/com/mapbox/androidauto/car/navigation/speedlimit/SpeedLimitWidget.kt
+++ b/android-auto/src/main/java/com/mapbox/androidauto/car/navigation/speedlimit/SpeedLimitWidget.kt
@@ -62,11 +62,11 @@ class SpeedLimitWidget(
     )
 
     fun update(expected: Expected<UpdateSpeedLimitError, UpdateSpeedLimitValue>) {
-        logAndroidAuto("SpeedLimitWidget update ${expected.isValue}")
         expected.value?.let {
             Logger.d(TAG, "${it.speedKPH}")
             Logger.d(TAG, it.speedLimitFormatter.format(it))
             if (lastSpeedLimitValue?.speedKPH == it.speedKPH) return
+            logAndroidAuto("SpeedLimitWidget update ${expected.isValue}")
             lastSpeedLimitValue = it
             viewWidgetHost.updateBitmap(
                 when (it.signFormat) {
@@ -168,7 +168,7 @@ class SpeedLimitWidget(
             lines.first(),
             width / 2f,
             height * SPEED_SIGN_BORDER_RATIO_MUTCD * SPEED_SIGN_PADDING_BORDER_RATIO_MUTCD -
-                    (textPaint.ascent() + textPaint.descent()),
+                (textPaint.ascent() + textPaint.descent()),
             textPaint
         )
         textPaint.textSize = textSize * 2f

--- a/android-auto/src/main/java/com/mapbox/androidauto/configuration/CarAppConfigOwner.kt
+++ b/android-auto/src/main/java/com/mapbox/androidauto/configuration/CarAppConfigOwner.kt
@@ -20,6 +20,17 @@ class CarAppConfigOwner internal constructor() {
 
     private lateinit var carAppConfigLiveData: MutableStateFlow<Configuration>
 
+    private val componentCallbacks = object : ComponentCallbacks {
+
+        override fun onConfigurationChanged(newConfig: Configuration) {
+            carAppConfigLiveData.value = newConfig
+        }
+
+        override fun onLowMemory() {
+            // noop
+        }
+    }
+
     internal fun setup(application: Application) {
         carAppConfigLiveData = MutableStateFlow(application.resources.configuration)
         application.registerComponentCallbacks(componentCallbacks)
@@ -38,17 +49,6 @@ class CarAppConfigOwner internal constructor() {
             configuration.locales.get(0)
         } else {
             configuration.locale
-        }
-    }
-
-    private val componentCallbacks = object : ComponentCallbacks {
-
-        override fun onConfigurationChanged(newConfig: Configuration) {
-            carAppConfigLiveData.value = newConfig
-        }
-
-        override fun onLowMemory() {
-            // noop
         }
     }
 }

--- a/android-auto/src/main/java/com/mapbox/androidauto/datastore/CarAppDataStoreOwner.kt
+++ b/android-auto/src/main/java/com/mapbox/androidauto/datastore/CarAppDataStoreOwner.kt
@@ -6,7 +6,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.preferencesDataStore
 import androidx.lifecycle.coroutineScope
-import com.mapbox.androidauto.MapboxCarApp
+import com.mapbox.navigation.lifecycle.MapboxNavigationApp
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -24,7 +24,7 @@ class CarAppDataStoreOwner internal constructor() {
     }
 
     fun launch(block: suspend CarAppDataStoreOwner.() -> Unit): Job =
-        MapboxCarApp.carAppLifecycleOwner.lifecycle.coroutineScope.launchWhenStarted {
+        MapboxNavigationApp.carAppLifecycleOwner.lifecycle.coroutineScope.launchWhenStarted {
             block()
         }
 

--- a/android-auto/src/main/java/com/mapbox/androidauto/deeplink/GeoDeeplink.kt
+++ b/android-auto/src/main/java/com/mapbox/androidauto/deeplink/GeoDeeplink.kt
@@ -1,0 +1,8 @@
+package com.mapbox.androidauto.deeplink
+
+import com.mapbox.geojson.Point
+
+data class GeoDeeplink(
+    val point: Point?,
+    val placeQuery: String?
+)

--- a/android-auto/src/main/java/com/mapbox/androidauto/deeplink/GeoDeeplinkGeocoding.kt
+++ b/android-auto/src/main/java/com/mapbox/androidauto/deeplink/GeoDeeplinkGeocoding.kt
@@ -1,0 +1,78 @@
+package com.mapbox.androidauto.deeplink
+
+import com.mapbox.api.geocoding.v5.GeocodingCriteria
+import com.mapbox.api.geocoding.v5.MapboxGeocoding
+import com.mapbox.api.geocoding.v5.models.GeocodingResponse
+import com.mapbox.geojson.Point
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+
+class GeoDeeplinkGeocoding(
+    private val accessToken: String
+) {
+    var currentMapboxGeocoding: MapboxGeocoding? = null
+
+    @Suppress("UseCheckOrError")
+    suspend fun requestPlaces(
+        geoDeeplink: GeoDeeplink,
+        origin: Point
+    ): GeocodingResponse? {
+        currentMapboxGeocoding?.cancelCall()
+        currentMapboxGeocoding = when {
+            geoDeeplink.point != null -> {
+                MapboxGeocoding.builder()
+                    .accessToken(accessToken)
+                    .query(geoDeeplink.point)
+                    .proximity(origin)
+                    .geocodingTypes(GeocodingCriteria.TYPE_ADDRESS)
+                    .build()
+            }
+            geoDeeplink.placeQuery != null -> {
+                MapboxGeocoding.builder()
+                    .accessToken(accessToken)
+                    .query(geoDeeplink.placeQuery)
+                    .proximity(origin)
+                    .build()
+            }
+            else -> {
+                throw IllegalStateException("GeoDeepLink must have a point or query")
+            }
+        }
+        return withContext(Dispatchers.IO) {
+            currentMapboxGeocoding?.asFlow()?.first()
+        }
+    }
+
+    fun cancel() {
+        currentMapboxGeocoding?.cancelCall()
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private fun MapboxGeocoding.asFlow(): Flow<GeocodingResponse?> = callbackFlow {
+        enqueueCall(object : Callback<GeocodingResponse> {
+            override fun onResponse(
+                call: Call<GeocodingResponse>,
+                response: Response<GeocodingResponse>
+            ) {
+                trySend(response.body())
+                close()
+            }
+
+            override fun onFailure(call: Call<GeocodingResponse>, t: Throwable) {
+                trySend(null)
+                close()
+            }
+        })
+        awaitClose {
+            cancelCall()
+        }
+    }
+}

--- a/android-auto/src/main/java/com/mapbox/androidauto/deeplink/GeoDeeplinkNavigateAction.kt
+++ b/android-auto/src/main/java/com/mapbox/androidauto/deeplink/GeoDeeplinkNavigateAction.kt
@@ -1,0 +1,48 @@
+package com.mapbox.androidauto.deeplink
+
+import android.content.Intent
+import androidx.car.app.CarContext
+import androidx.car.app.Screen
+import androidx.lifecycle.Lifecycle
+import com.mapbox.androidauto.logAndroidAuto
+import com.mapbox.examples.androidauto.car.MainCarContext
+import com.mapbox.examples.androidauto.car.placeslistonmap.PlaceMarkerRenderer
+import com.mapbox.examples.androidauto.car.placeslistonmap.PlacesListItemMapper
+import com.mapbox.examples.androidauto.car.placeslistonmap.PlacesListOnMapLayerUtil
+import com.mapbox.examples.androidauto.car.placeslistonmap.PlacesListOnMapScreen
+import com.mapbox.examples.androidauto.car.search.SearchCarContext
+
+class GeoDeeplinkNavigateAction(
+    val carContext: CarContext,
+    val lifecycle: Lifecycle
+) {
+    fun onNewIntent(intent: Intent): Screen? {
+        val geoDeeplink = GeoDeeplinkParser.parse(intent.dataString)
+            ?: return null
+        return preparePlacesListOnMapScreen(geoDeeplink)
+    }
+
+    private fun preparePlacesListOnMapScreen(geoDeeplink: GeoDeeplink): Screen {
+        logAndroidAuto("GeoDeeplinkNavigateAction preparePlacesListOnMapScreen")
+        val mainCarContext = MainCarContext(carContext)
+        return PlacesListOnMapScreen(
+            mainCarContext,
+            GeoDeeplinkPlacesListOnMapProvider(
+                GeoDeeplinkGeocoding(
+                    mainCarContext.mapboxNavigation.navigationOptions.accessToken!!
+                ),
+                geoDeeplink
+            ),
+            PlacesListOnMapLayerUtil(),
+            PlacesListItemMapper(
+                PlaceMarkerRenderer(mainCarContext.carContext),
+                mainCarContext
+                    .mapboxNavigation
+                    .navigationOptions
+                    .distanceFormatterOptions
+                    .unitType
+            ),
+            SearchCarContext(mainCarContext)
+        )
+    }
+}

--- a/android-auto/src/main/java/com/mapbox/androidauto/deeplink/GeoDeeplinkParser.kt
+++ b/android-auto/src/main/java/com/mapbox/androidauto/deeplink/GeoDeeplinkParser.kt
@@ -1,0 +1,81 @@
+package com.mapbox.androidauto.deeplink
+
+import com.mapbox.geojson.Point
+import java.net.URLDecoder
+
+/**
+ * This class is responsible for converting external geo deeplinks into internal domain objects.
+ *
+ * Public documentation for the geo deeplink can be found here
+ * https://developers.google.com/maps/documentation/urls/android-intents
+ */
+object GeoDeeplinkParser {
+
+    private var destination: GeoDeeplink? = null
+
+    fun getDestinationAndErase(): GeoDeeplink? {
+        val destination = destination
+        GeoDeeplinkParser.destination = null
+        return destination
+    }
+
+    fun parse(geoDeeplink: String?): GeoDeeplink? {
+        val destination = if (geoDeeplink != null && geoDeeplink.startsWith("geo:")) {
+            val query = geoDeeplink.substring("geo:".length)
+            val args = query.split("?")
+            val point = args[0].toPoint() ?: args.query()?.queryCoordinates()
+            val placeQuery = args.query()?.removeCoordinates()
+            GeoDeeplink(point = point, placeQuery = placeQuery)
+        } else {
+            null
+        }
+        GeoDeeplinkParser.destination = destination
+        return destination
+    }
+
+    @Suppress("ComplexCondition")
+    private fun String.toPoint(): Point? {
+        val coordinates = this.split(",")
+        if (coordinates.size < 2) return null
+        val latitude = coordinates[0].toCoordinate()
+        // try to replace an encoded whitespace
+        val longitude = coordinates[1].toCoordinate() ?: coordinates[1].replace("%20", "").toCoordinate()
+        return if (latitude != null && longitude != null && (latitude != 0.0 || longitude != 0.0)) {
+            Point.fromLngLat(longitude.toDouble(), latitude.toDouble())
+        } else {
+            null
+        }
+    }
+
+    private fun String.toCoordinate(): Double? {
+        val coordinate = this.toDoubleOrNull()
+        return if (coordinate != null && coordinate.isFinite()) {
+            coordinate
+        } else {
+            null
+        }
+    }
+
+    private fun String.queryCoordinates(): Point? {
+        val decode = URLDecoder.decode(this, "UTF-8")
+        return decode.decodeAtSign() ?: decode.decodeParenthesis()
+    }
+
+    private fun String.decodeAtSign(): Point? = split("@")
+        .lastOrNull()
+        ?.toPoint()
+
+    private fun String.decodeParenthesis(): Point? = split("(", ")")
+        .firstOrNull()
+        ?.toPoint()
+
+    private fun List<String>.query(): String? = firstOrNull { it.startsWith("q=") }
+        ?.substring("q=".length)
+
+    private fun String.removeCoordinates(): String? {
+        val decode = URLDecoder.decode(this, "UTF-8")
+        val withoutAtSign = decode.split("@").firstOrNull()
+        val fromInsideParenthesis = decode?.split("(", ")")?.getOrNull(1)
+        return fromInsideParenthesis ?: withoutAtSign
+    }
+}

--- a/android-auto/src/main/java/com/mapbox/androidauto/deeplink/GeoDeeplinkPlacesListOnMapProvider.kt
+++ b/android-auto/src/main/java/com/mapbox/androidauto/deeplink/GeoDeeplinkPlacesListOnMapProvider.kt
@@ -1,0 +1,39 @@
+package com.mapbox.androidauto.deeplink
+
+import com.mapbox.androidauto.MapboxCarApp
+import com.mapbox.bindgen.Expected
+import com.mapbox.bindgen.ExpectedFactory
+import com.mapbox.examples.androidauto.car.placeslistonmap.PlacesListOnMapProvider
+import com.mapbox.examples.androidauto.car.search.GetPlacesError
+import com.mapbox.examples.androidauto.car.search.PlaceRecord
+import com.mapbox.examples.androidauto.car.search.PlaceRecordMapper
+import com.mapbox.geojson.Point
+
+class GeoDeeplinkPlacesListOnMapProvider(
+    private val geoDeeplinkGeocoding: GeoDeeplinkGeocoding,
+    private val geoDeeplink: GeoDeeplink
+) : PlacesListOnMapProvider {
+
+    @Suppress("ReturnCount")
+    override suspend fun getPlaces(): Expected<GetPlacesError, List<PlaceRecord>> {
+        // Wait for an origin location
+        val origin = MapboxCarApp.carAppServices.location().validLocation()
+            ?.run { Point.fromLngLat(longitude, latitude) }
+            ?: return ExpectedFactory.createError(
+                GetPlacesError("Did not find current location.", null)
+            )
+
+        // Request places from the origin to the deeplink place
+        val result = geoDeeplinkGeocoding.requestPlaces(geoDeeplink, origin)
+            ?: return ExpectedFactory.createError(
+                GetPlacesError("Error getting geo deeplink places.", null)
+            )
+        return ExpectedFactory.createValue(
+            result.features().map(PlaceRecordMapper::fromCarmenFeature)
+        )
+    }
+
+    override fun cancel() {
+        geoDeeplinkGeocoding.cancel()
+    }
+}

--- a/android-auto/src/main/java/com/mapbox/androidauto/navigation/audioguidance/CarAudioGuidanceUi.kt
+++ b/android-auto/src/main/java/com/mapbox/androidauto/navigation/audioguidance/CarAudioGuidanceUi.kt
@@ -28,8 +28,7 @@ class CarAudioGuidanceUi(val screen: Screen) {
                 repeatOnLifecycle(Lifecycle.State.STARTED) {
                     MapboxCarApp.carAppServices.audioGuidance().stateFlow()
                         .distinctUntilChanged { old, new ->
-                            old.isMuted != new.isMuted ||
-                                    old.isPlayable != new.isPlayable
+                            old.isMuted != new.isMuted || old.isPlayable != new.isPlayable
                         }
                         .collect { screen.invalidate() }
                 }

--- a/android-auto/src/main/java/com/mapbox/androidauto/navigation/location/CarAppLocation.kt
+++ b/android-auto/src/main/java/com/mapbox/androidauto/navigation/location/CarAppLocation.kt
@@ -1,6 +1,8 @@
 package com.mapbox.androidauto.navigation.location
 
+import android.location.Location
 import com.mapbox.androidauto.MapboxCarApp
+import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.ui.maps.location.NavigationLocationProvider
 
 /**
@@ -8,5 +10,15 @@ import com.mapbox.navigation.ui.maps.location.NavigationLocationProvider
  * Access through [MapboxCarApp.carAppServices].
  */
 interface CarAppLocation {
+    /**
+     * location provider that is attached to [MapboxNavigation].
+     * This provider can be used as a relay for the latest map coordinates.
+     */
     val navigationLocationProvider: NavigationLocationProvider
+
+    /**
+     * Helper function that will suspend until a location is found,
+     * or until the coroutine scope is no longer active.
+     */
+    suspend fun validLocation(): Location?
 }

--- a/android-auto/src/main/java/com/mapbox/androidauto/navigation/location/impl/CarAppLocationImpl.kt
+++ b/android-auto/src/main/java/com/mapbox/androidauto/navigation/location/impl/CarAppLocationImpl.kt
@@ -3,40 +3,68 @@ package com.mapbox.androidauto.navigation.location.impl
 import android.location.Location
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
-import com.mapbox.androidauto.MapboxCarApp
 import com.mapbox.androidauto.navigation.location.CarAppLocation
-import com.mapbox.navigation.core.MapboxNavigationProvider
+import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.trip.session.LocationMatcherResult
 import com.mapbox.navigation.core.trip.session.LocationObserver
+import com.mapbox.navigation.lifecycle.MapboxNavigationApp
+import com.mapbox.navigation.lifecycle.MapboxNavigationObserver
 import com.mapbox.navigation.ui.maps.location.NavigationLocationProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.withContext
 
 internal class CarAppLocationImpl : CarAppLocation {
 
     override val navigationLocationProvider = NavigationLocationProvider()
 
-    private val locationObserver = object : LocationObserver {
+    val navigationLocationObserver = object : MapboxNavigationObserver {
+        val locationObserver = object : LocationObserver {
 
-        override fun onNewLocationMatcherResult(locationMatcherResult: LocationMatcherResult) {
-            navigationLocationProvider.changePosition(
-                locationMatcherResult.enhancedLocation,
-                locationMatcherResult.keyPoints,
-            )
+            override fun onNewLocationMatcherResult(locationMatcherResult: LocationMatcherResult) {
+                navigationLocationProvider.changePosition(
+                    locationMatcherResult.enhancedLocation,
+                    locationMatcherResult.keyPoints,
+                )
+            }
+
+            override fun onNewRawLocation(rawLocation: Location) {
+                // no op
+            }
         }
 
-        override fun onNewRawLocation(rawLocation: Location) {
-            // no op
+        override fun onAttached(mapboxNavigation: MapboxNavigation) {
+            mapboxNavigation.registerLocationObserver(locationObserver)
+        }
+
+        override fun onDetached(mapboxNavigation: MapboxNavigation?) {
+            mapboxNavigation?.unregisterLocationObserver(locationObserver)
         }
     }
 
     init {
-        MapboxCarApp.carAppLifecycleOwner.lifecycle.addObserver(object : DefaultLifecycleObserver {
+        MapboxNavigationApp.carAppLifecycleOwner.lifecycle.addObserver(object : DefaultLifecycleObserver {
             override fun onStart(owner: LifecycleOwner) {
-                MapboxNavigationProvider.retrieve().registerLocationObserver(locationObserver)
+                MapboxNavigationApp.registerObserver(navigationLocationObserver)
             }
 
             override fun onStop(owner: LifecycleOwner) {
-                MapboxNavigationProvider.retrieve().unregisterLocationObserver(locationObserver)
+                MapboxNavigationApp.unregisterObserver(navigationLocationObserver)
             }
         })
+    }
+
+    override suspend fun validLocation(): Location? = withContext(Dispatchers.Unconfined) {
+        var location: Location? = navigationLocationProvider.lastLocation
+        while (isActive && location == null) {
+            delay(DELAY_MILLISECONDS)
+            location = navigationLocationProvider.lastLocation
+        }
+        return@withContext location
+    }
+
+    companion object {
+        const val DELAY_MILLISECONDS = 100L
     }
 }

--- a/android-auto/src/main/java/com/mapbox/androidauto/surfacelayer/textview/CarScene2d.kt
+++ b/android-auto/src/main/java/com/mapbox/androidauto/surfacelayer/textview/CarScene2d.kt
@@ -25,8 +25,7 @@ class CarScene2d : CarSurfaceLayer() {
         )
 
         logAndroidAuto(
-            "CarScene2d visibleAreaChanged " +
-                    "visibleArea:$visibleArea: edgeInsets:$edgeInsets"
+            "CarScene2d visibleAreaChanged visibleArea:$visibleArea: edgeInsets:$edgeInsets",
         )
     }
 }

--- a/android-auto/src/main/java/com/mapbox/androidauto/surfacelayer/textview/CarTextLayerHost.kt
+++ b/android-auto/src/main/java/com/mapbox/androidauto/surfacelayer/textview/CarTextLayerHost.kt
@@ -165,7 +165,7 @@ class CarTextLayerHost : CustomLayerHost {
         gl_Position = mvp_matrix * vec4(aPosition, 0, 1.0);
         vTexCoord = aTexCoord;
       }
-    """.trimIndent()
+        """.trimIndent()
 
         private val FRAGMENT_SHADER_CODE = """
       precision mediump float;
@@ -180,7 +180,13 @@ class CarTextLayerHost : CustomLayerHost {
         vec4 background = uFillColor * (1.0-texture_color.a);
         gl_FragColor = background + texture_color;
       }
-    """.trimIndent()
+        """.trimIndent()
+
+        private val emptyBitmap: Bitmap by lazy {
+            Bitmap.createBitmap(10, 10, Bitmap.Config.ARGB_8888).also {
+                it.eraseColor(Color.TRANSPARENT)
+            }
+        }
 
         private fun loadVertexShader(): Int =
             loadShader(GLES20.GL_VERTEX_SHADER, VERTEX_SHADER_CODE)
@@ -195,12 +201,6 @@ class CarTextLayerHost : CustomLayerHost {
                 // add the source code to the shader and compile it
                 GLES20.glShaderSource(shader, shaderCode)
                 GLES20.glCompileShader(shader)
-            }
-        }
-
-        private val emptyBitmap: Bitmap by lazy {
-            Bitmap.createBitmap(10, 10, Bitmap.Config.ARGB_8888).also {
-                it.eraseColor(Color.TRANSPARENT)
             }
         }
     }

--- a/android-auto/src/main/java/com/mapbox/androidauto/surfacelayer/textview/CarTextModel2d.kt
+++ b/android-auto/src/main/java/com/mapbox/androidauto/surfacelayer/textview/CarTextModel2d.kt
@@ -54,18 +54,24 @@ class CarTextModel2d : CarSurfaceLayer() {
         val scaleX = bitmap.width / width.toFloat()
         val scaleY = bitmap.height / height.toFloat()
 
-        Matrix.translateM(modelMatrix, 0,
+        Matrix.translateM(
+            modelMatrix, 0,
             translateX.toFloat(),
             translateY.toFloat(),
-            0.0f)
-        Matrix.translateM(modelMatrix, 0,
+            0.0f,
+        )
+        Matrix.translateM(
+            modelMatrix, 0,
             (width / 2.0f).toFloat() - bitmap.width / 2.0f,
             height.toFloat() - bitmap.height,
-            0.0f)
-        Matrix.scaleM(modelMatrix, 0,
+            0.0f,
+        )
+        Matrix.scaleM(
+            modelMatrix, 0,
             width.toFloat() * scaleX,
             height.toFloat() * scaleY,
-            1.0f)
+            1.0f,
+        )
     }
 
     private companion object {

--- a/android-auto/src/main/java/com/mapbox/examples/androidauto/car/MainCarScreen.kt
+++ b/android-auto/src/main/java/com/mapbox/examples/androidauto/car/MainCarScreen.kt
@@ -7,9 +7,9 @@ import androidx.car.app.navigation.model.NavigationTemplate
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.mapbox.androidauto.car.navigation.roadlabel.RoadLabelSurfaceLayer
+import com.mapbox.androidauto.car.navigation.speedlimit.CarSpeedLimitRenderer
 import com.mapbox.androidauto.logAndroidAuto
 import com.mapbox.examples.androidauto.car.location.CarLocationRenderer
-import com.mapbox.androidauto.car.navigation.speedlimit.CarSpeedLimitRenderer
 import com.mapbox.examples.androidauto.car.navigation.CarNavigationCamera
 import com.mapbox.examples.androidauto.car.preview.CarRouteLine
 
@@ -32,16 +32,6 @@ class MainCarScreen(
         mainCarContext.mapboxNavigation
     )
 
-    override fun onGetTemplate(): Template {
-        return NavigationTemplate.Builder()
-            .setBackgroundColor(CarColor.PRIMARY)
-            .setActionStrip(
-                MainActionStrip(mainCarContext).builder()
-                    .build()
-            )
-            .build()
-    }
-
     init {
         logAndroidAuto("MainCarScreen constructor")
         lifecycle.addObserver(object : DefaultLifecycleObserver {
@@ -63,5 +53,12 @@ class MainCarScreen(
                 mainCarContext.mapboxCarMap.unregisterObserver(carNavigationCamera)
             }
         })
+    }
+
+    override fun onGetTemplate(): Template {
+        return NavigationTemplate.Builder()
+            .setBackgroundColor(CarColor.PRIMARY)
+            .setActionStrip(MainActionStrip(mainCarContext).builder().build())
+            .build()
     }
 }

--- a/android-auto/src/main/java/com/mapbox/examples/androidauto/car/MainScreenManager.kt
+++ b/android-auto/src/main/java/com/mapbox/examples/androidauto/car/MainScreenManager.kt
@@ -18,9 +18,19 @@ import com.mapbox.examples.androidauto.car.navigation.CarActiveGuidanceCarContex
 class MainScreenManager(
     val mainCarContext: MainCarContext
 ) : DefaultLifecycleObserver {
+
+    private val carAppStateObserver = Observer<CarAppState> { carAppState ->
+        val currentScreen = currentScreen(carAppState)
+        val screenManager = mainCarContext.carContext.getCarService(ScreenManager::class.java)
+        logAndroidAuto("MainScreenManager screen change ${currentScreen.javaClass.simpleName}")
+        if (screenManager.top.javaClass != currentScreen.javaClass) {
+            screenManager.push(currentScreen)
+        }
+    }
+
     fun currentScreen(): Screen = currentScreen(MapboxCarApp.carAppState.value!!)
 
-    fun currentScreen(carAppState: CarAppState): Screen {
+    private fun currentScreen(carAppState: CarAppState): Screen {
         return when (carAppState) {
             FreeDriveState, RoutePreviewState -> MainCarScreen(mainCarContext)
             ActiveGuidanceState, ArrivalState -> {
@@ -29,21 +39,13 @@ class MainScreenManager(
         }
     }
 
-    val carAppStateObserver = Observer<CarAppState> { carAppState ->
-        val currentScreen = currentScreen(carAppState)
-        val screenManager = mainCarContext.carContext.getCarService(ScreenManager::class.java)
-        if (screenManager.top.javaClass != currentScreen.javaClass) {
-            screenManager.push(currentScreen)
-        }
-    }
-
-    override fun onResume(owner: LifecycleOwner) {
-        logAndroidAuto("MainCarSession onResume")
+    override fun onCreate(owner: LifecycleOwner) {
+        logAndroidAuto("MainScreenManager onCreate")
         MapboxCarApp.carAppState.observe(owner, carAppStateObserver)
     }
 
-    override fun onPause(owner: LifecycleOwner) {
-        logAndroidAuto("MainCarSession onPause")
+    override fun onDestroy(owner: LifecycleOwner) {
+        logAndroidAuto("MainScreenManager onDestroy")
         MapboxCarApp.carAppState.removeObserver(carAppStateObserver)
     }
 }

--- a/android-auto/src/main/java/com/mapbox/examples/androidauto/car/navigation/ActiveGuidanceScreen.kt
+++ b/android-auto/src/main/java/com/mapbox/examples/androidauto/car/navigation/ActiveGuidanceScreen.kt
@@ -42,6 +42,34 @@ class ActiveGuidanceScreen(
     private val carAudioGuidanceUi = CarAudioGuidanceUi(this)
     private val carRouteProgressObserver = CarNavigationInfoObserver(carActiveGuidanceContext)
 
+    init {
+        logAndroidAuto("ActiveGuidanceScreen constructor")
+        lifecycle.addObserver(object : DefaultLifecycleObserver {
+
+            override fun onResume(owner: LifecycleOwner) {
+                logAndroidAuto("ActiveGuidanceScreen onResume")
+                carActiveGuidanceContext.mapboxCarMap.registerObserver(carLocationRenderer)
+                carActiveGuidanceContext.mapboxCarMap.registerObserver(roadLabelSurfaceLayer)
+                carActiveGuidanceContext.mapboxCarMap.registerObserver(carSpeedLimitRenderer)
+                carActiveGuidanceContext.mapboxCarMap.registerObserver(carNavigationCamera)
+                carActiveGuidanceContext.mapboxCarMap.registerObserver(carRouteLine)
+                carRouteProgressObserver.start {
+                    invalidate()
+                }
+            }
+
+            override fun onPause(owner: LifecycleOwner) {
+                logAndroidAuto("ActiveGuidanceScreen onPause")
+                carActiveGuidanceContext.mapboxCarMap.unregisterObserver(roadLabelSurfaceLayer)
+                carActiveGuidanceContext.mapboxCarMap.unregisterObserver(carLocationRenderer)
+                carActiveGuidanceContext.mapboxCarMap.unregisterObserver(carSpeedLimitRenderer)
+                carActiveGuidanceContext.mapboxCarMap.unregisterObserver(carNavigationCamera)
+                carActiveGuidanceContext.mapboxCarMap.unregisterObserver(carRouteLine)
+                carRouteProgressObserver.stop()
+            }
+        })
+    }
+
     override fun onGetTemplate(): Template {
         logAndroidAuto("ActiveGuidanceScreen onGetTemplate")
         val builder = NavigationTemplate.Builder()
@@ -77,33 +105,5 @@ class ActiveGuidanceScreen(
         logAndroidAuto("ActiveGuidanceScreen stopNavigation")
         MapboxNavigationProvider.retrieve().setRoutes(emptyList())
         MapboxCarApp.updateCarAppState(FreeDriveState)
-    }
-
-    init {
-        logAndroidAuto("ActiveGuidanceScreen constructor")
-        lifecycle.addObserver(object : DefaultLifecycleObserver {
-
-            override fun onResume(owner: LifecycleOwner) {
-                logAndroidAuto("ActiveGuidanceScreen onResume")
-                carActiveGuidanceContext.mapboxCarMap.registerObserver(carLocationRenderer)
-                carActiveGuidanceContext.mapboxCarMap.registerObserver(roadLabelSurfaceLayer)
-                carActiveGuidanceContext.mapboxCarMap.registerObserver(carSpeedLimitRenderer)
-                carActiveGuidanceContext.mapboxCarMap.registerObserver(carNavigationCamera)
-                carActiveGuidanceContext.mapboxCarMap.registerObserver(carRouteLine)
-                carRouteProgressObserver.start {
-                    invalidate()
-                }
-            }
-
-            override fun onPause(owner: LifecycleOwner) {
-                logAndroidAuto("ActiveGuidanceScreen onPause")
-                carActiveGuidanceContext.mapboxCarMap.unregisterObserver(roadLabelSurfaceLayer)
-                carActiveGuidanceContext.mapboxCarMap.unregisterObserver(carLocationRenderer)
-                carActiveGuidanceContext.mapboxCarMap.unregisterObserver(carSpeedLimitRenderer)
-                carActiveGuidanceContext.mapboxCarMap.unregisterObserver(carNavigationCamera)
-                carActiveGuidanceContext.mapboxCarMap.unregisterObserver(carRouteLine)
-                carRouteProgressObserver.stop()
-            }
-        })
     }
 }

--- a/android-auto/src/main/java/com/mapbox/examples/androidauto/car/navigation/CarLocationsOverviewCamera.kt
+++ b/android-auto/src/main/java/com/mapbox/examples/androidauto/car/navigation/CarLocationsOverviewCamera.kt
@@ -33,6 +33,29 @@ class CarLocationsOverviewCamera(
         private set
     private var latestLocation: Location? = null
 
+    private val locationObserver = object : LocationObserver {
+
+        override fun onNewRawLocation(rawLocation: Location) {
+            // not handled
+        }
+
+        override fun onNewLocationMatcherResult(locationMatcherResult: LocationMatcherResult) {
+            // Initialize the camera at the current location. The next location will
+            // transition into the overview mode.
+            latestLocation = locationMatcherResult.enhancedLocation
+            viewportDataSource.onLocationChanged(locationMatcherResult.enhancedLocation)
+            viewportDataSource.evaluate()
+            if (!isLocationInitialized) {
+                isLocationInitialized = true
+                val instantTransition = NavigationCameraTransitionOptions.Builder()
+                    .maxDuration(0)
+                    .build()
+
+                navigationCamera.requestNavigationCameraToOverview(stateTransitionOptions = instantTransition)
+            }
+        }
+    }
+
     override fun loaded(mapboxCarMapSurface: MapboxCarMapSurface) {
         super.loaded(mapboxCarMapSurface)
         this.mapboxCarMapSurface = mapboxCarMapSurface
@@ -82,30 +105,6 @@ class CarLocationsOverviewCamera(
             viewportDataSource.additionalPointsToFrameForOverview(points)
             viewportDataSource.clearRouteData()
             viewportDataSource.evaluate()
-        }
-    }
-
-    private val locationObserver = object : LocationObserver {
-        override fun onNewRawLocation(rawLocation: Location) {
-            // not handled
-        }
-
-        override fun onNewLocationMatcherResult(locationMatcherResult: LocationMatcherResult) {
-            // Initialize the camera at the current location. The next location will
-            // transition into the overview mode.
-            latestLocation = locationMatcherResult.enhancedLocation
-            viewportDataSource.onLocationChanged(locationMatcherResult.enhancedLocation)
-            viewportDataSource.evaluate()
-            if (!isLocationInitialized) {
-                isLocationInitialized = true
-                val instantTransition = NavigationCameraTransitionOptions.Builder()
-                    .maxDuration(0)
-                    .build()
-
-                navigationCamera.requestNavigationCameraToOverview(
-                    stateTransitionOptions = instantTransition
-                )
-            }
         }
     }
 

--- a/android-auto/src/main/java/com/mapbox/examples/androidauto/car/placeslistonmap/PlacesListItemMapper.kt
+++ b/android-auto/src/main/java/com/mapbox/examples/androidauto/car/placeslistonmap/PlacesListItemMapper.kt
@@ -34,8 +34,7 @@ class PlacesListItemMapper(
         places.filter { it.coordinate != null }.forEach { placeRecord ->
             val distanceUnits = getDistanceUnits(unitType)
             val distance: Double = TurfMeasurement.distance(
-                Point.fromLngLat(anchorLocation.longitude,
-                    anchorLocation.latitude),
+                Point.fromLngLat(anchorLocation.longitude, anchorLocation.latitude),
                 placeRecord.coordinate!!,
                 distanceUnits.second
             )

--- a/android-auto/src/main/java/com/mapbox/examples/androidauto/car/preview/CarRoutePreviewScreen.kt
+++ b/android-auto/src/main/java/com/mapbox/examples/androidauto/car/preview/CarRoutePreviewScreen.kt
@@ -13,14 +13,14 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.mapbox.androidauto.ActiveGuidanceState
 import com.mapbox.androidauto.MapboxCarApp
+import com.mapbox.androidauto.car.navigation.speedlimit.CarSpeedLimitRenderer
 import com.mapbox.androidauto.logAndroidAuto
 import com.mapbox.api.directions.v5.models.DirectionsRoute
 import com.mapbox.examples.androidauto.R
 import com.mapbox.examples.androidauto.car.MainActionStrip
 import com.mapbox.examples.androidauto.car.location.CarLocationRenderer
-import com.mapbox.androidauto.car.navigation.speedlimit.CarSpeedLimitRenderer
-import com.mapbox.examples.androidauto.car.search.PlaceRecord
 import com.mapbox.examples.androidauto.car.navigation.CarNavigationCamera
+import com.mapbox.examples.androidauto.car.search.PlaceRecord
 
 /**
  * After a destination has been selected. This view previews the route and lets
@@ -40,6 +40,38 @@ class CarRoutePreviewScreen(
         routePreviewCarContext.mapboxNavigation,
         CarNavigationCamera.CameraMode.OVERVIEW
     )
+
+    private val backPressCallback = object : OnBackPressedCallback(true) {
+
+        override fun handleOnBackPressed() {
+            logAndroidAuto("CarRoutePreviewScreen OnBackPressedCallback")
+            routePreviewCarContext.mapboxNavigation.setRoutes(listOf())
+            screenManager.pop()
+        }
+    }
+
+    init {
+        logAndroidAuto("CarRoutePreviewScreen constructor")
+        lifecycle.addObserver(object : DefaultLifecycleObserver {
+            override fun onResume(owner: LifecycleOwner) {
+                logAndroidAuto("CarRoutePreviewScreen onResume")
+                routePreviewCarContext.carContext.onBackPressedDispatcher.addCallback(backPressCallback)
+                routePreviewCarContext.mapboxCarMap.registerObserver(carLocationRenderer)
+                routePreviewCarContext.mapboxCarMap.registerObserver(carSpeedLimitRenderer)
+                routePreviewCarContext.mapboxCarMap.registerObserver(carNavigationCamera)
+                routePreviewCarContext.mapboxCarMap.registerObserver(carRouteLine)
+            }
+
+            override fun onPause(owner: LifecycleOwner) {
+                logAndroidAuto("CarRoutePreviewScreen onPause")
+                backPressCallback.remove()
+                routePreviewCarContext.mapboxCarMap.unregisterObserver(carLocationRenderer)
+                routePreviewCarContext.mapboxCarMap.unregisterObserver(carSpeedLimitRenderer)
+                routePreviewCarContext.mapboxCarMap.unregisterObserver(carNavigationCamera)
+                routePreviewCarContext.mapboxCarMap.unregisterObserver(carRouteLine)
+            }
+        })
+    }
 
     override fun onGetTemplate(): Template {
         val listBuilder = ItemList.Builder()
@@ -90,38 +122,8 @@ class CarRoutePreviewScreen(
                     .setOnClickListener {
                         MapboxCarApp.updateCarAppState(ActiveGuidanceState)
                     }
-                    .build())
+                    .build(),
+            )
             .build()
-    }
-
-    private val backPressCallback = object : OnBackPressedCallback(true) {
-        override fun handleOnBackPressed() {
-            logAndroidAuto("CarRoutePreviewScreen OnBackPressedCallback")
-            routePreviewCarContext.mapboxNavigation.setRoutes(listOf())
-            screenManager.pop()
-        }
-    }
-
-    init {
-        logAndroidAuto("CarRoutePreviewScreen constructor")
-        lifecycle.addObserver(object : DefaultLifecycleObserver {
-            override fun onResume(owner: LifecycleOwner) {
-                logAndroidAuto("CarRoutePreviewScreen onResume")
-                routePreviewCarContext.carContext.onBackPressedDispatcher.addCallback(backPressCallback)
-                routePreviewCarContext.mapboxCarMap.registerObserver(carLocationRenderer)
-                routePreviewCarContext.mapboxCarMap.registerObserver(carSpeedLimitRenderer)
-                routePreviewCarContext.mapboxCarMap.registerObserver(carNavigationCamera)
-                routePreviewCarContext.mapboxCarMap.registerObserver(carRouteLine)
-            }
-
-            override fun onPause(owner: LifecycleOwner) {
-                logAndroidAuto("CarRoutePreviewScreen onPause")
-                backPressCallback.remove()
-                routePreviewCarContext.mapboxCarMap.unregisterObserver(carLocationRenderer)
-                routePreviewCarContext.mapboxCarMap.unregisterObserver(carSpeedLimitRenderer)
-                routePreviewCarContext.mapboxCarMap.unregisterObserver(carNavigationCamera)
-                routePreviewCarContext.mapboxCarMap.unregisterObserver(carRouteLine)
-            }
-        })
     }
 }

--- a/android-auto/src/main/java/com/mapbox/examples/androidauto/car/search/FavoritesApi.kt
+++ b/android-auto/src/main/java/com/mapbox/examples/androidauto/car/search/FavoritesApi.kt
@@ -31,8 +31,9 @@ class FavoritesApi(private val favoritesProvider: FavoritesDataProvider) : Place
     suspend fun getFavorites(): Expected<GetPlacesError, List<FavoriteRecord>> {
         getAllTask?.cancel()
         return suspendCoroutine { continuation ->
-            getAllTask = favoritesProvider.getAll(object :
-                CompletionCallback<List<FavoriteRecord>> {
+            getAllTask = favoritesProvider.getAll(
+                object : CompletionCallback<List<FavoriteRecord>> {
+
                     override fun onComplete(result: List<FavoriteRecord>) {
                         continuation.resume(ExpectedFactory.createValue(result))
                     }
@@ -44,7 +45,8 @@ class FavoritesApi(private val favoritesProvider: FavoritesDataProvider) : Place
                             )
                         )
                     }
-            })
+                },
+            )
         }
     }
 
@@ -65,9 +67,10 @@ class FavoritesApi(private val favoritesProvider: FavoritesDataProvider) : Place
                             )
                         )
                     }
-                })
-            }
+                },
+            )
         }
+    }
 
     suspend fun removeFavorite(favoriteId: String): Expected<GetPlacesError, Boolean> {
         removeFavoriteTask?.cancel()
@@ -86,9 +89,10 @@ class FavoritesApi(private val favoritesProvider: FavoritesDataProvider) : Place
                             )
                         )
                     }
-                })
-            }
+                },
+            )
         }
+    }
 
     private fun cancelRequests() {
         getAllTask?.cancel()

--- a/android-auto/src/main/java/com/mapbox/examples/androidauto/car/search/PlaceRecord.kt
+++ b/android-auto/src/main/java/com/mapbox/examples/androidauto/car/search/PlaceRecord.kt
@@ -11,4 +11,38 @@ class PlaceRecord(
     val coordinate: Point?,
     val description: String? = null,
     val categories: List<String> = listOf()
-)
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as PlaceRecord
+
+        if (id != other.id) return false
+        if (name != other.name) return false
+        if (coordinate != other.coordinate) return false
+        if (description != other.description) return false
+        if (categories != other.categories) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = id.hashCode()
+        result = 31 * result + name.hashCode()
+        result = 31 * result + (coordinate?.hashCode() ?: 0)
+        result = 31 * result + (description?.hashCode() ?: 0)
+        result = 31 * result + categories.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "PlaceRecord(" +
+            "id='$id', " +
+            "name='$name', " +
+            "coordinate=$coordinate, " +
+            "description=$description, " +
+            "categories=$categories" +
+            ")"
+    }
+}

--- a/android-auto/src/main/java/com/mapbox/examples/androidauto/car/search/PlaceRecordMapper.kt
+++ b/android-auto/src/main/java/com/mapbox/examples/androidauto/car/search/PlaceRecordMapper.kt
@@ -1,5 +1,6 @@
 package com.mapbox.examples.androidauto.car.search
 
+import com.mapbox.api.geocoding.v5.models.CarmenFeature
 import com.mapbox.navigation.utils.internal.ifNonNull
 import com.mapbox.search.record.FavoriteRecord
 import com.mapbox.search.result.SearchAddress
@@ -32,4 +33,14 @@ object PlaceRecordMapper {
         ifNonNull(address?.houseNumber, address?.street) { houseNumber, street ->
             "$houseNumber $street"
         }
+
+    fun fromCarmenFeature(carmenFeature: CarmenFeature): PlaceRecord {
+        return PlaceRecord(
+            id = carmenFeature.id() ?: "",
+            name = carmenFeature.text() ?: "",
+            coordinate = carmenFeature.center(),
+            description = carmenFeature.placeName(),
+            categories = carmenFeature.placeType() ?: emptyList()
+        )
+    }
 }

--- a/android-auto/src/main/java/com/mapbox/examples/androidauto/car/search/SearchScreen.kt
+++ b/android-auto/src/main/java/com/mapbox/examples/androidauto/car/search/SearchScreen.kt
@@ -27,6 +27,27 @@ class SearchScreen(
     @VisibleForTesting
     var itemList = buildErrorItemList(R.string.car_search_no_results)
 
+    private val carRouteRequestCallback = object : CarRouteRequestCallback {
+
+        override fun onRoutesReady(placeRecord: PlaceRecord, routes: List<DirectionsRoute>) {
+            val routePreviewCarContext = RoutePreviewCarContext(searchCarContext.mainCarContext)
+
+            screenManager.push(CarRoutePreviewScreen(routePreviewCarContext, placeRecord, routes))
+        }
+
+        override fun onUnknownCurrentLocation() {
+            onErrorItemList(R.string.car_search_unknown_current_location)
+        }
+
+        override fun onDestinationLocationUnknown() {
+            onErrorItemList(R.string.car_search_unknown_search_location)
+        }
+
+        override fun onNoRoutesFound() {
+            onErrorItemList(R.string.car_search_no_results)
+        }
+    }
+
     override fun onGetTemplate(): Template {
         return SearchTemplate.Builder(
             object : SearchTemplate.SearchCallback {
@@ -60,10 +81,10 @@ class SearchScreen(
     }
 
     private fun searchItemRow(suggestion: SearchSuggestion) = Row.Builder()
-            .setTitle(suggestion.name)
-            .addText(formatDistance(suggestion))
-            .setOnClickListener { onClickSearch(suggestion) }
-            .build()
+        .setTitle(suggestion.name)
+        .addText(formatDistance(suggestion))
+        .setOnClickListener { onClickSearch(suggestion) }
+        .build()
 
     private fun formatDistance(searchSuggestion: SearchSuggestion): CharSequence {
         val distanceMeters = searchSuggestion.distanceMeters ?: return ""
@@ -83,36 +104,14 @@ class SearchScreen(
         }
     }
 
-    private val carRouteRequestCallback = object : CarRouteRequestCallback {
-        override fun onRoutesReady(placeRecord: PlaceRecord, routes: List<DirectionsRoute>) {
-            val routePreviewCarContext = RoutePreviewCarContext(searchCarContext.mainCarContext)
-
-            screenManager.push(
-                CarRoutePreviewScreen(routePreviewCarContext, placeRecord, routes)
-            )
-        }
-
-        override fun onUnknownCurrentLocation() {
-            onErrorItemList(R.string.car_search_unknown_current_location)
-        }
-
-        override fun onDestinationLocationUnknown() {
-            onErrorItemList(R.string.car_search_unknown_search_location)
-        }
-
-        override fun onNoRoutesFound() {
-            onErrorItemList(R.string.car_search_no_results)
-        }
-    }
-
     private fun onErrorItemList(@StringRes stringRes: Int) {
         itemList = buildErrorItemList(stringRes)
         invalidate()
     }
 
     private fun buildErrorItemList(@StringRes stringRes: Int) = ItemList.Builder()
-            .setNoItemsMessage(carContext.getString(stringRes))
-            .build()
+        .setNoItemsMessage(carContext.getString(stringRes))
+        .build()
 
     companion object {
         // TODO turn this into something typesafe

--- a/android-auto/src/main/java/com/mapbox/examples/androidauto/car/settings/CarSettingsScreen.kt
+++ b/android-auto/src/main/java/com/mapbox/examples/androidauto/car/settings/CarSettingsScreen.kt
@@ -19,15 +19,16 @@ class CarSettingsScreen(
     private val carSettingsStorage = settingsCarContext.carSettingsStorage
 
     override fun onGetTemplate(): Template {
-        val templateBuilder = ListTemplate.Builder()
-            .setSingleList(ItemList.Builder()
+        val templateBuilder = ListTemplate.Builder().setSingleList(
+            ItemList.Builder()
                 .addItem(
                     buildRowToggle(
                         R.string.car_settings_toggle_place_holder,
                         R.string.car_settings_toggle_place_holder_key
                     )
                 )
-                .build())
+                .build(),
+        )
         return templateBuilder
             .setHeaderAction(Action.BACK)
             .setTitle(carContext.getString(R.string.car_settings_title))

--- a/android-auto/src/main/java/com/mapbox/navigation/lifecycle/CarAppLifecycleOwner.kt
+++ b/android-auto/src/main/java/com/mapbox/navigation/lifecycle/CarAppLifecycleOwner.kt
@@ -1,17 +1,16 @@
-package com.mapbox.androidauto.lifecycle
+package com.mapbox.navigation.lifecycle
 
 import android.app.Activity
 import android.app.Application
 import android.os.Bundle
 import androidx.annotation.VisibleForTesting
-import androidx.car.app.Session
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
 import com.mapbox.androidauto.logAndroidAuto
 
-class CarAppLifecycleOwner internal constructor() : LifecycleOwner {
+internal class CarAppLifecycleOwner : LifecycleOwner {
 
     // Keeps track of the activities created and foregrounded
     private var activitiesCreated = 0
@@ -27,16 +26,6 @@ class CarAppLifecycleOwner internal constructor() : LifecycleOwner {
 
     private val lifecycleRegistry = LifecycleRegistry(this)
         .apply { currentState = Lifecycle.State.INITIALIZED }
-
-    override fun getLifecycle(): Lifecycle = lifecycleRegistry
-
-    internal fun setup(application: Application) {
-        application.registerActivityLifecycleCallbacks(activityLifecycleCallbacks)
-    }
-
-    internal fun setupCar(session: Session) {
-        session.lifecycle.addObserver(carLifecycleObserver)
-    }
 
     @VisibleForTesting
     internal val carLifecycleObserver = object : DefaultLifecycleObserver {
@@ -153,5 +142,15 @@ class CarAppLifecycleOwner internal constructor() : LifecycleOwner {
                 }
             }
         }
+    }
+
+    override fun getLifecycle(): Lifecycle = lifecycleRegistry
+
+    internal fun setup(application: Application) {
+        application.registerActivityLifecycleCallbacks(activityLifecycleCallbacks)
+    }
+
+    internal fun setupCar(carLifecycle: Lifecycle) {
+        carLifecycle.addObserver(carLifecycleObserver)
     }
 }

--- a/android-auto/src/main/java/com/mapbox/navigation/lifecycle/MapboxNavigationApp.kt
+++ b/android-auto/src/main/java/com/mapbox/navigation/lifecycle/MapboxNavigationApp.kt
@@ -1,0 +1,71 @@
+package com.mapbox.navigation.lifecycle
+
+import android.app.Application
+import androidx.lifecycle.LifecycleOwner
+import com.mapbox.navigation.core.MapboxNavigation
+
+/**
+ * Manages a default lifecycle for [MapboxNavigation].
+ *
+ * Call [MapboxNavigationApp.setup] from your application.
+ * And then you can register/unregister observers [MapboxNavigationApp.registerObserver]
+ * that can observe data coming from the [MapboxNavigation] object.
+ *
+ * Example Application
+ * ```
+ * class MyApplication : Application() {
+ *   override fun onCreate() {
+ *     MapboxNavigationApp.setup(this) { application ->
+ *       NavigationOptions.Builder(application)
+ *         .accessToken(getString(R.string.mapbox_access_token))
+ *         .build()
+ *     }
+ *   }
+ * }
+ * ```
+ */
+object MapboxNavigationApp {
+
+    internal val carAppLifecycleOwner: CarAppLifecycleOwner = CarAppLifecycleOwner()
+    private lateinit var mapboxNavigationOwner: MapboxNavigationOwner
+
+    /**
+     * Get the lifecycle of the car and app. It is started when either the car or
+     * app is in foreground. When both the car and app have been closed, the lifecycle
+     * is stopped. The lifecycle is never destroyed.
+     */
+    val lifecycleOwner: LifecycleOwner = carAppLifecycleOwner
+
+    /**
+     * Call [MapboxNavigationApp.setup] from your application.
+     */
+    fun setup(
+        application: Application,
+        mapboxNavigationInitializer: MapboxNavigationInitializer
+    ) {
+        mapboxNavigationOwner = MapboxNavigationOwner(application, mapboxNavigationInitializer)
+        carAppLifecycleOwner.setup(application)
+        carAppLifecycleOwner.lifecycle.addObserver(mapboxNavigationOwner.carAppLifecycleObserver)
+    }
+
+    /**
+     * Register an observer to receive the [MapboxNavigation] instance.
+     */
+    fun registerObserver(mapboxNavigationObserver: MapboxNavigationObserver) {
+        check(this::mapboxNavigationOwner.isInitialized) {
+            """
+                The MapboxNavigationInitializer is not setup.
+                In your Application.onCreate function, set your implementation of
+                MapboxNavigationInitializer through the MapboxNavigationApp.setup function
+            """.trimIndent()
+        }
+        mapboxNavigationOwner.register(mapboxNavigationObserver)
+    }
+
+    /**
+     * Unregister the observer that was registered through [registerObserver].
+     */
+    fun unregisterObserver(mapboxNavigationObserver: MapboxNavigationObserver) {
+        mapboxNavigationOwner.unregister(mapboxNavigationObserver)
+    }
+}

--- a/android-auto/src/main/java/com/mapbox/navigation/lifecycle/MapboxNavigationInitializer.kt
+++ b/android-auto/src/main/java/com/mapbox/navigation/lifecycle/MapboxNavigationInitializer.kt
@@ -1,0 +1,18 @@
+package com.mapbox.navigation.lifecycle
+
+import android.app.Application
+import com.mapbox.navigation.base.options.NavigationOptions
+import com.mapbox.navigation.core.MapboxNavigation
+
+/**
+ * Function provided to the [MapboxNavigationApp.setup] function. This allows you
+ * to customize the [NavigationOptions].
+ */
+fun interface MapboxNavigationInitializer {
+    /**
+     * Called when the [MapboxNavigation] needs to be is created. This can be called
+     * multiple times after [Application.onCreate] because the [MapboxNavigation] is destroyed
+     * when all activities and services are destroyed.
+     */
+    fun create(application: Application): NavigationOptions
+}

--- a/android-auto/src/main/java/com/mapbox/navigation/lifecycle/MapboxNavigationObserver.kt
+++ b/android-auto/src/main/java/com/mapbox/navigation/lifecycle/MapboxNavigationObserver.kt
@@ -1,0 +1,63 @@
+package com.mapbox.navigation.lifecycle
+
+import com.mapbox.navigation.core.MapboxNavigation
+
+/**
+ * This allows you to attach and detach [MapboxNavigation] observers
+ * from any component with a lifecycle.
+ *
+ * Example of observing locations with a view model
+ * ```
+ * class MyViewModel : ViewModel() {
+ *   private val locationObserver = LocationObserver()
+ *
+ *   val location: LiveData<Location> = locationObserver.location.asLiveData()
+ *
+ *   init {
+ *     MapboxNavigationApp.register(myMapboxNavigationObserver)
+ *   }
+ *
+ *   override fun onCleared() {
+ *     MapboxNavigationApp.unregister(myMapboxNavigationObserver)
+ *   }
+ * }
+ *
+ * class LocationNavigationObserver : MapboxNavigationObserver {
+ *   private val mutableLocation = MutableStateFlow<LocationMatcherResult?>(null)
+ *   val locationFlow: Flow<LocationMatcherResult?> = mutableLocation
+ *
+ *   private val locationObserver = object : LocationObserver {
+ *     override fun onNewLocationMatcherResult(locationMatcherResult: LocationMatcherResult) {
+ *       mutableLocation.value = locationMatcherResult
+ *     }
+ *
+ *     override fun onNewRawLocation(rawLocation: Location) {
+ *       // no op
+ *     }
+ *   }
+ *
+ *   override fun onAttached(mapboxNavigation: MapboxNavigation) {
+ *     mapboxNavigation.registerLocationObserver(locationObserver)
+ *   }
+ *
+ *   override fun onDetached(mapboxNavigation: MapboxNavigation?) {
+ *     mapboxNavigation?.unregisterLocationObserver(locationObserver)
+ *   }
+ * }
+ * ```
+ */
+interface MapboxNavigationObserver {
+    /**
+     * Emits the active MapboxNavigation object.
+     * After registering through [MapboxNavigationApp.registerObserver], the
+     * current [MapboxNavigation] object will be emitted.
+     */
+    fun onAttached(mapboxNavigation: MapboxNavigation)
+
+    /**
+     * Is called when all activities are destroyed and the car session is destroyed.
+     * This will also be called when the observer is unregistered by the call to
+     * [MapboxNavigationApp.unregisterObserver].
+     */
+    fun onDetached(mapboxNavigation: MapboxNavigation?)
+}

--- a/android-auto/src/main/java/com/mapbox/navigation/lifecycle/MapboxNavigationOwner.kt
+++ b/android-auto/src/main/java/com/mapbox/navigation/lifecycle/MapboxNavigationOwner.kt
@@ -1,0 +1,46 @@
+package com.mapbox.navigation.lifecycle
+
+import android.app.Application
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import com.mapbox.androidauto.logAndroidAuto
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.MapboxNavigationProvider
+import java.util.concurrent.CopyOnWriteArraySet
+
+internal class MapboxNavigationOwner(
+    private val application: Application,
+    private val mapboxNavigationInitializer: MapboxNavigationInitializer
+) {
+    private val services = CopyOnWriteArraySet<MapboxNavigationObserver>()
+    private var mapboxNavigation: MapboxNavigation? = null
+    internal val carAppLifecycleObserver = object : DefaultLifecycleObserver {
+
+        override fun onStart(owner: LifecycleOwner) {
+            logAndroidAuto("MapboxNavigationOwner navigation.onStart")
+            val navigationOptions = mapboxNavigationInitializer.create(application)
+            check(!MapboxNavigationProvider.isCreated()) {
+                "MapboxNavigation should only be destroyed by the MapboxNavigationLifetime"
+            }
+            val mapboxNavigation = MapboxNavigationProvider.create(navigationOptions)
+            this@MapboxNavigationOwner.mapboxNavigation = mapboxNavigation
+            services.forEach { it.onAttached(mapboxNavigation) }
+        }
+
+        override fun onStop(owner: LifecycleOwner) {
+            logAndroidAuto("MapboxNavigationOwner navigation.onStop")
+            services.forEach { it.onDetached(mapboxNavigation!!) }
+            MapboxNavigationProvider.destroy()
+        }
+    }
+
+    fun register(mapboxNavigationObserver: MapboxNavigationObserver) = apply {
+        mapboxNavigation?.let { mapboxNavigationObserver.onAttached(it) }
+        services.add(mapboxNavigationObserver)
+    }
+
+    fun unregister(mapboxNavigationObserver: MapboxNavigationObserver) {
+        mapboxNavigationObserver.onDetached(mapboxNavigation)
+        services.remove(mapboxNavigationObserver)
+    }
+}

--- a/android-auto/src/test/java/com/mapbox/androidauto/car/navigation/lanes/CarLaneMapperTest.kt
+++ b/android-auto/src/test/java/com/mapbox/androidauto/car/navigation/lanes/CarLaneMapperTest.kt
@@ -1,7 +1,7 @@
 package com.mapbox.androidauto.car.navigation.lanes
 
-import androidx.car.app.navigation.model.Lane
 import androidx.car.app.navigation.model.LaneDirection
+import com.mapbox.navigation.ui.maneuver.model.Lane
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
@@ -15,23 +15,25 @@ class CarLaneMapperTest {
 
     @Test
     fun `empty values should return empty list`() {
-        val lanes = carLaneMapper.mapLanes(mockk {
+        val laneGuidance = mockk<Lane> {
             every { allLanes } returns emptyList()
-        })
+        }
+        val lanes = carLaneMapper.mapLanes(laneGuidance)
 
         assertTrue(lanes.isEmpty())
     }
 
     @Test
     fun `map a lane that is valid but not active`() {
-        val lanes: List<Lane> = carLaneMapper.mapLanes(mockk {
+        val laneGuidance = mockk<Lane> {
             every { allLanes } returns listOf(
                 mockk {
                     every { isActive } returns false
                     every { directions } returns listOf("straight")
                 }
             )
-        })
+        }
+        val lanes = carLaneMapper.mapLanes(laneGuidance)
 
         assertEquals(1, lanes.size)
         val lane = lanes[0]
@@ -42,14 +44,15 @@ class CarLaneMapperTest {
 
     @Test
     fun `map a lane with multiple indications`() {
-        val lanes: List<Lane> = carLaneMapper.mapLanes(mockk {
+        val laneGuidance = mockk<Lane> {
             every { allLanes } returns listOf(
                 mockk {
                     every { isActive } returns true
                     every { directions } returns listOf("straight", "right")
                 }
             )
-        })
+        }
+        val lanes = carLaneMapper.mapLanes(laneGuidance)
 
         assertEquals(1, lanes.size)
         val lane = lanes[0]
@@ -62,14 +65,15 @@ class CarLaneMapperTest {
 
     @Test
     fun `map a lane without valid indication`() {
-        val lanes: List<Lane> = carLaneMapper.mapLanes(mockk {
+        val laneGuidance = mockk<Lane> {
             every { allLanes } returns listOf(
                 mockk {
                     every { isActive } returns false
                     every { directions } returns listOf("left")
                 }
             )
-        })
+        }
+        val lanes = carLaneMapper.mapLanes(laneGuidance)
 
         assertEquals(1, lanes.size)
         val lane = lanes[0]

--- a/android-auto/src/test/java/com/mapbox/androidauto/deeplink/GeoDeeplinkParserTest.kt
+++ b/android-auto/src/test/java/com/mapbox/androidauto/deeplink/GeoDeeplinkParserTest.kt
@@ -1,0 +1,130 @@
+@file:Suppress(
+    "MagicNumber",
+    "MaximumLineLength",
+    "MaxLineLength",
+    "LongMethod"
+)
+
+package com.mapbox.androidauto.deeplink
+
+import android.content.Intent
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+
+class GeoDeeplinkParserTest {
+
+    @Test
+    fun `correct geo string`() {
+        listOf(
+            GeoTestParams(
+                "geo:37.788151,-122.407543",
+                37.788151,
+                -122.407543
+            ),
+            GeoTestParams(
+                "geo:37.788151, -122.407543",
+                37.788151,
+                -122.407543
+            ),
+            GeoTestParams(
+                "geo:37.788151,%20-122.407543",
+                37.788151,
+                -122.407543
+            ),
+            GeoTestParams(
+                "geo:37.788151,-122.407543?q=3107 Washington Street, San Francisco, California 94115, United States",
+                37.788151,
+                -122.407543,
+                "3107 Washington Street, San Francisco, California 94115, United States"
+            ),
+            GeoTestParams(
+                "geo:0.0,-62.785138",
+                0.0,
+                -62.785138
+            ),
+            GeoTestParams(
+                "geo:37.788151,0.0",
+                37.788151,
+                0.0
+            ),
+            GeoTestParams(
+                "geo:0,0?q=%E5%93%81%E5%B7%9D%E5%8C%BA%E5%A4%A7%E4%BA%95%206-16-16%20%E3%83%A1%E3%82%BE%E3%83%B3%E9%B9%BF%E5%B3%B6%E3%81%AE%E7%A2%A7201%4035.595404%2C139.731737",
+                35.595404,
+                139.731737,
+                "品川区大井 6-16-16 メゾン鹿島の碧201"
+            ),
+            GeoTestParams(
+                "geo:0,0?q=54.356152,18.642736(ul. 3 maja 12, 80-802 Gdansk, Poland)",
+                54.356152,
+                18.642736,
+                placeQuery = "ul. 3 maja 12, 80-802 Gdansk, Poland"
+            ),
+            GeoTestParams(
+                "geo:0,0?q=1600 Amphitheatre Parkway, Mountain+View, California",
+                latitude = null,
+                longitude = null,
+                placeQuery = "1600 Amphitheatre Parkway, Mountain View, California"
+            )
+        ).forEach { expected ->
+            val intent: Intent = mockk()
+            every { intent.dataString } answers { expected.dataString }
+
+            val geoDeeplink = GeoDeeplinkParser.parse(intent.dataString)
+
+            val actualLatitude = geoDeeplink?.point?.latitude()
+            val actualLongitude = geoDeeplink?.point?.longitude()
+            val actualPlaceQuery = geoDeeplink?.placeQuery
+            assertEquals(
+                expected.latitude,
+                actualLatitude,
+                "Latitude expected ${expected.latitude} but was $actualLatitude"
+            )
+            assertEquals(
+                expected.longitude,
+                actualLongitude,
+                "Longitude expected ${expected.longitude} but was $actualLongitude"
+            )
+            assertEquals(
+                expected.placeQuery,
+                actualPlaceQuery,
+                "Place query expected ${expected.placeQuery} but was $actualPlaceQuery"
+            )
+        }
+    }
+
+    @Test
+    fun `incorrect geo string`() {
+        listOf(
+            GeoTestParams("geo:,"),
+            GeoTestParams("geo:,35.595404"),
+            GeoTestParams("geo:35.595404,")
+        ).forEach { params ->
+            val intent: Intent = mockk()
+            every { intent.dataString } answers { params.dataString }
+
+            val geoDeeplink = GeoDeeplinkParser.parse(intent.dataString)
+
+            assertNull(geoDeeplink?.point)
+        }
+    }
+
+    @Test
+    fun `destination erases when it is gotten`() {
+        val intent: Intent = mockk()
+        every { intent.dataString } answers { "geo:37.788151,-122.407543" }
+        GeoDeeplinkParser.parse(intent.dataString)
+        GeoDeeplinkParser.getDestinationAndErase()
+
+        assertEquals(null, GeoDeeplinkParser.getDestinationAndErase())
+    }
+}
+
+data class GeoTestParams(
+    val dataString: String,
+    val latitude: Double? = null,
+    val longitude: Double? = null,
+    val placeQuery: String? = null
+)

--- a/android-auto/src/test/java/com/mapbox/androidauto/deeplink/GeoDeeplinkPlacesListOnMapProviderTest.kt
+++ b/android-auto/src/test/java/com/mapbox/androidauto/deeplink/GeoDeeplinkPlacesListOnMapProviderTest.kt
@@ -1,0 +1,86 @@
+@file:Suppress("NoMockkVerifyImport")
+
+package com.mapbox.androidauto.deeplink
+
+import android.location.Location
+import com.mapbox.androidauto.CarAppServicesProvider
+import com.mapbox.androidauto.MapboxCarApp
+import com.mapbox.androidauto.navigation.location.CarAppLocation
+import com.mapbox.androidauto.testing.MainCoroutineRule
+import com.mapbox.api.geocoding.v5.models.CarmenFeature
+import com.mapbox.api.geocoding.v5.models.GeocodingResponse
+import com.mapbox.geojson.Point
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.unmockkObject
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+class GeoDeeplinkPlacesListOnMapProviderTest {
+
+    @get:Rule
+    var coroutineRule = MainCoroutineRule()
+
+    @Test
+    fun cancel() {
+        val geoDeeplinkGeocoding = mockk<GeoDeeplinkGeocoding>(relaxed = true)
+        val geoDeeplink = mockk<GeoDeeplink>()
+
+        GeoDeeplinkPlacesListOnMapProvider(geoDeeplinkGeocoding, geoDeeplink).cancel()
+
+        verify { geoDeeplinkGeocoding.cancel() }
+    }
+
+    @Test
+    fun getPlaces() = coroutineRule.runBlockingTest {
+        mockkObject(MapboxCarApp)
+        val location = mockk<Location> {
+            every { longitude } returns -121.8544717
+            every { latitude } returns 45.6824467
+        }
+        val point = Point.fromLngLat(-121.8544717, 45.6824467)
+        val carmenFeature1 = mockk<CarmenFeature> {
+            every { id() } returns "1"
+            every { text() } returns ""
+            every { center() } returns point
+            every { placeName() } returns "enchanted forrest"
+            every { placeType() } returns emptyList()
+        }
+        val carmenFeature2 = mockk<CarmenFeature> {
+            every { id() } returns "1"
+            every { text() } returns ""
+            every { center() } returns point
+            every { placeName() } returns "enchanted forrest"
+            every { placeType() } returns emptyList()
+        }
+        val response = mockk<GeocodingResponse> {
+            every { features() } returns listOf(carmenFeature1, carmenFeature2)
+        }
+        val carAppLocation = mockk<CarAppLocation> {
+            coEvery { validLocation() } returns location
+        }
+        val mockCarAppServices = mockk<CarAppServicesProvider> {
+            every { location() } returns carAppLocation
+        }
+        every { MapboxCarApp.carAppServices } returns mockCarAppServices
+        val originSlot = slot<Point>()
+        val geoDeeplink = mockk<GeoDeeplink>()
+        val geoDeeplinkGeocoding = mockk<GeoDeeplinkGeocoding>(relaxed = true) {
+            coEvery { requestPlaces(geoDeeplink, capture(originSlot)) } returns response
+        }
+
+        val result = GeoDeeplinkPlacesListOnMapProvider(geoDeeplinkGeocoding, geoDeeplink)
+            .getPlaces()
+            .value!!
+
+        assertEquals(45.6824467, originSlot.captured.latitude(), 0.0001)
+        assertEquals(-121.8544717, originSlot.captured.longitude(), 0.0001)
+        assertEquals(2, result.size)
+        unmockkObject(MapboxCarApp)
+    }
+}

--- a/android-auto/src/test/java/com/mapbox/androidauto/navigation/audioguidance/impl/MapboxAudioGuidanceVoiceTest.kt
+++ b/android-auto/src/test/java/com/mapbox/androidauto/navigation/audioguidance/impl/MapboxAudioGuidanceVoiceTest.kt
@@ -44,8 +44,7 @@ class MapboxAudioGuidanceVoiceTest {
         val voiceInstructions = mockk<VoiceInstructions> {
             every { announcement() } returns "Turn right on Market"
         }
-        carAppAudioGuidanceVoice.speak(voiceInstructions).collect {
-                speechAnnouncement: SpeechAnnouncement? ->
+        carAppAudioGuidanceVoice.speak(voiceInstructions).collect { speechAnnouncement ->
             assertEquals("Turn right on Market", speechAnnouncement!!.announcement)
         }
     }
@@ -62,19 +61,19 @@ class MapboxAudioGuidanceVoiceTest {
     fun `should play fallback when speech api fails`() = coroutineRule.runBlockingTest {
         every { speechApi.generate(any(), any()) } answers {
             val consumer = secondArg<MapboxNavigationConsumer<Expected<SpeechError, SpeechValue>>>()
-            consumer.accept(ExpectedFactory.createError(mockk {
+            val error = mockk<SpeechError> {
                 every { fallback } returns mockk {
                     every { announcement } returns "Turn right on Market"
                 }
-            }))
+            }
+            consumer.accept(ExpectedFactory.createError(error))
         }
         mockSuccessfulVoiceInstructionsPlayer()
 
         val voiceInstructions = mockk<VoiceInstructions> {
             every { announcement() } returns "This message fails"
         }
-        carAppAudioGuidanceVoice.speak(voiceInstructions).collect {
-                speechAnnouncement: SpeechAnnouncement? ->
+        carAppAudioGuidanceVoice.speak(voiceInstructions).collect { speechAnnouncement ->
             assertEquals("Turn right on Market", speechAnnouncement!!.announcement)
         }
     }

--- a/android-auto/src/test/java/com/mapbox/androidauto/navigation/audioguidance/impl/MapboxVoiceInstructionsTest.kt
+++ b/android-auto/src/test/java/com/mapbox/androidauto/navigation/audioguidance/impl/MapboxVoiceInstructionsTest.kt
@@ -1,8 +1,10 @@
 package com.mapbox.androidauto.navigation.audioguidance.impl
 
 import com.mapbox.androidauto.testing.MainCoroutineRule
+import com.mapbox.api.directions.v5.models.VoiceInstructions
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.directions.session.RoutesObserver
+import com.mapbox.navigation.core.directions.session.RoutesUpdatedResult
 import com.mapbox.navigation.core.trip.session.TripSessionState
 import com.mapbox.navigation.core.trip.session.TripSessionStateObserver
 import com.mapbox.navigation.core.trip.session.VoiceInstructionsObserver
@@ -35,14 +37,16 @@ class MapboxVoiceInstructionsTest {
             )
         }
         every { mapboxNavigation.registerRoutesObserver(any()) } answers {
-            firstArg<RoutesObserver>().onRoutesChanged(mockk {
+            val result = mockk<RoutesUpdatedResult> {
                 every { routes } returns listOf(mockk(), mockk())
-            })
+            }
+            firstArg<RoutesObserver>().onRoutesChanged(result)
         }
         every { mapboxNavigation.registerVoiceInstructionsObserver(any()) } answers {
-            firstArg<VoiceInstructionsObserver>().onNewVoiceInstructions(mockk {
+            val voiceInstructions = mockk<VoiceInstructions> {
                 every { announcement() } returns "Left on Broadway"
-            })
+            }
+            firstArg<VoiceInstructionsObserver>().onNewVoiceInstructions(voiceInstructions)
         }
 
         val state = carAppVoiceInstructions.voiceInstructions().take(2).toList()
@@ -59,17 +63,20 @@ class MapboxVoiceInstructionsTest {
             )
         }
         every { mapboxNavigation.registerRoutesObserver(any()) } answers {
-            firstArg<RoutesObserver>().onRoutesChanged(mockk {
+            val result = mockk<RoutesUpdatedResult> {
                 every { routes } returns listOf(mockk(), mockk())
-            })
+            }
+            firstArg<RoutesObserver>().onRoutesChanged(result)
         }
         every { mapboxNavigation.registerVoiceInstructionsObserver(any()) } answers {
-            firstArg<VoiceInstructionsObserver>().onNewVoiceInstructions(mockk {
+            val firstVoiceInstructions = mockk<VoiceInstructions> {
                 every { announcement() } returns "Left on Broadway"
-            })
-            firstArg<VoiceInstructionsObserver>().onNewVoiceInstructions(mockk {
+            }
+            firstArg<VoiceInstructionsObserver>().onNewVoiceInstructions(firstVoiceInstructions)
+            val secondVoiceInstructions = mockk<VoiceInstructions> {
                 every { announcement() } returns "Right on Pennsylvania"
-            })
+            }
+            firstArg<VoiceInstructionsObserver>().onNewVoiceInstructions(secondVoiceInstructions)
         }
 
         val voiceInstruction = carAppVoiceInstructions.voiceInstructions().take(3).toList()
@@ -87,9 +94,10 @@ class MapboxVoiceInstructionsTest {
             )
         }
         every { mapboxNavigation.registerRoutesObserver(any()) } answers {
-            firstArg<RoutesObserver>().onRoutesChanged(mockk {
+            val result = mockk<RoutesUpdatedResult> {
                 every { routes } returns emptyList()
-            })
+            }
+            firstArg<RoutesObserver>().onRoutesChanged(result)
         }
 
         val state = carAppVoiceInstructions.voiceInstructions().first()

--- a/android-auto/src/test/java/com/mapbox/androidauto/search/PlaceRecordMapperTest.kt
+++ b/android-auto/src/test/java/com/mapbox/androidauto/search/PlaceRecordMapperTest.kt
@@ -1,5 +1,7 @@
 package com.mapbox.androidauto.search
 
+import com.mapbox.androidauto.testing.FileUtils
+import com.mapbox.api.geocoding.v5.models.CarmenFeature
 import com.mapbox.examples.androidauto.car.search.PlaceRecordMapper
 import com.mapbox.geojson.Point
 import com.mapbox.search.record.FavoriteRecord
@@ -40,5 +42,20 @@ class PlaceRecordMapperTest {
         assertEquals(37.80561066, placeRecord.coordinate?.latitude()!!, 0.000001)
         assertEquals("1389 Jefferson Street", placeRecord.description)
         assertTrue(placeRecord.categories.isEmpty())
+    }
+
+    @Test
+    fun `should map geocodingResponse's CarmenFeature to placeRecord`() {
+        val json = FileUtils.loadJsonFixture("carmen_feature_oakland_coffee.json")
+        val carmenFeature = CarmenFeature.fromJson(json)
+
+        val placeRecord = PlaceRecordMapper.fromCarmenFeature(carmenFeature)
+
+        assertEquals(placeRecord.id, "poi.773094129083")
+        assertEquals(placeRecord.name, "Starbucks")
+        assertEquals(placeRecord.coordinate?.latitude(), 37.800456)
+        assertEquals(placeRecord.coordinate?.longitude(), -122.273904)
+        assertEquals(placeRecord.description, "Starbucks, 801 Broadway, Oakland, California 94607, United States")
+        assertEquals(placeRecord.categories, listOf("poi"))
     }
 }

--- a/android-auto/src/test/java/com/mapbox/androidauto/testing/FileUtils.kt
+++ b/android-auto/src/test/java/com/mapbox/androidauto/testing/FileUtils.kt
@@ -1,0 +1,9 @@
+package com.mapbox.androidauto.testing
+
+object FileUtils {
+    fun loadJsonFixture(fileName: String): String {
+        return javaClass.classLoader?.getResourceAsStream(fileName)
+            ?.bufferedReader()
+            ?.use { it.readText() }!!
+    }
+}

--- a/android-auto/src/test/java/com/mapbox/androidauto/testing/TestMapboxAudioGuidanceServices.kt
+++ b/android-auto/src/test/java/com/mapbox/androidauto/testing/TestMapboxAudioGuidanceServices.kt
@@ -15,10 +15,6 @@ import kotlinx.coroutines.flow.onEach
 
 class TestMapboxAudioGuidanceServices {
 
-    fun emitVoiceInstruction(state: MapboxVoiceInstructions.State) {
-        voiceInstructionsFlow.tryEmit(state)
-    }
-
     private val voiceInstructionsFlow = MutableStateFlow<MapboxVoiceInstructions.State>(
         MapboxVoiceInstructionsState()
     )
@@ -50,6 +46,10 @@ class TestMapboxAudioGuidanceServices {
         every {
             mapboxAudioGuidanceVoice(any())
         } returns mapboxAudioGuidanceVoice
+    }
+
+    fun emitVoiceInstruction(state: MapboxVoiceInstructions.State) {
+        voiceInstructionsFlow.tryEmit(state)
     }
 
     companion object {

--- a/android-auto/src/test/java/com/mapbox/examples/androidauto/car/navigation/CarDistanceFormatterTest.kt
+++ b/android-auto/src/test/java/com/mapbox/examples/androidauto/car/navigation/CarDistanceFormatterTest.kt
@@ -1,6 +1,7 @@
 package com.mapbox.examples.androidauto.car.navigation
 
 import androidx.car.app.model.Distance
+import com.mapbox.navigation.base.formatter.Rounding
 import com.mapbox.navigation.base.formatter.UnitType
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -24,7 +25,7 @@ class CarDistanceFormatterTest {
         val distance = mapper.carDistance(CarDistanceFormatter.smallDistanceMeters - 1)
 
         // This is also testing that feet distance is always a whole number
-        assertEquals(652.0, distance.displayDistance, 0.0)
+        assertEquals(1300.0, distance.displayDistance, 0.0)
         assertEquals(Distance.UNIT_FEET, distance.displayUnit)
     }
 
@@ -35,7 +36,7 @@ class CarDistanceFormatterTest {
         val smallDistance = mapper.carDistance(CarDistanceFormatter.smallDistanceMeters + 1)
         val mediumDistance = mapper.carDistance(CarDistanceFormatter.mediumDistanceMeters - 1)
 
-        assertEquals(0.1249, smallDistance.displayDistance, 0.001)
+        assertEquals(0.249169771, smallDistance.displayDistance, 0.001)
         assertEquals(Distance.UNIT_MILES_P1, smallDistance.displayUnit)
         assertEquals(6.2130, mediumDistance.displayDistance, 0.001)
         assertEquals(Distance.UNIT_MILES_P1, mediumDistance.displayUnit)
@@ -52,6 +53,16 @@ class CarDistanceFormatterTest {
     }
 
     @Test
+    fun `IMPERIAL should convert small distance with rounding increment to UNIT_FEET`() {
+        val mapper = CarDistanceFormatter(UnitType.IMPERIAL)
+
+        val distance = mapper.carDistance(10.0, Rounding.INCREMENT_FIVE)
+
+        assertEquals(30.0000, distance.displayDistance, 0.0)
+        assertEquals(Distance.UNIT_FEET, distance.displayUnit)
+    }
+
+    @Test
     fun `METRIC should convert NaN distance to 0 UNIT_METERS`() {
         val mapper = CarDistanceFormatter(UnitType.METRIC)
 
@@ -65,9 +76,9 @@ class CarDistanceFormatterTest {
     fun `METRIC should convert small distance to UNIT_METERS`() {
         val mapper = CarDistanceFormatter(UnitType.METRIC)
 
-        val distance = mapper.carDistance(CarDistanceFormatter.smallDistanceMeters - 1)
+        val distance = mapper.carDistance(199.0)
 
-        assertEquals(199.0, distance.displayDistance, 0.0)
+        assertEquals(150.0, distance.displayDistance, 0.0)
         assertEquals(Distance.UNIT_METERS, distance.displayUnit)
     }
 
@@ -78,7 +89,7 @@ class CarDistanceFormatterTest {
         val smallDistance = mapper.carDistance(CarDistanceFormatter.smallDistanceMeters + 1)
         val mediumDistance = mapper.carDistance(CarDistanceFormatter.mediumDistanceMeters - 1)
 
-        assertEquals(0.201, smallDistance.displayDistance, 0.0)
+        assertEquals(0.401, smallDistance.displayDistance, 0.0)
         assertEquals(Distance.UNIT_KILOMETERS_P1, smallDistance.displayUnit)
         assertEquals(9.999, mediumDistance.displayDistance, 0.001)
         assertEquals(Distance.UNIT_KILOMETERS_P1, mediumDistance.displayUnit)

--- a/android-auto/src/test/java/com/mapbox/examples/androidauto/car/navigation/CarLocationsOverviewCameraTest.kt
+++ b/android-auto/src/test/java/com/mapbox/examples/androidauto/car/navigation/CarLocationsOverviewCameraTest.kt
@@ -36,7 +36,7 @@ class CarLocationsOverviewCameraTest : MapboxRobolectricTestRunner() {
 
         camera.loaded(mapboxCarMapSurface)
 
-        verify { mapboxMap.setCamera(any< CameraOptions>()) }
+        verify { mapboxMap.setCamera(any<CameraOptions>()) }
         verify { mapboxNavigation.registerLocationObserver(any()) }
         assertNotNull(camera.viewportDataSource)
         assertNotNull(camera.navigationCamera)

--- a/android-auto/src/test/java/com/mapbox/examples/androidauto/car/navigation/CarNavigationEtaMapperTest.kt
+++ b/android-auto/src/test/java/com/mapbox/examples/androidauto/car/navigation/CarNavigationEtaMapperTest.kt
@@ -28,7 +28,7 @@ class CarNavigationEtaMapperTest {
 
         val result = mapper.from(routeProgress)
 
-        assertEquals(45.0, result!!.remainingDistance!!.displayDistance, 0.0)
+        assertEquals(50.0, result!!.remainingDistance!!.displayDistance, 0.0)
         assertEquals(154000, result.remainingTimeSeconds)
     }
 }

--- a/android-auto/src/test/java/com/mapbox/navigation/lifecycle/CarAppLifecycleOwnerTest.kt
+++ b/android-auto/src/test/java/com/mapbox/navigation/lifecycle/CarAppLifecycleOwnerTest.kt
@@ -1,6 +1,6 @@
 @file:Suppress("NoMockkVerifyImport")
 
-package com.mapbox.androidauto.lifecycle
+package com.mapbox.navigation.lifecycle
 
 import android.app.Activity
 import androidx.lifecycle.DefaultLifecycleObserver
@@ -14,12 +14,11 @@ import org.junit.Test
 
 class CarAppLifecycleOwnerTest : MapboxRobolectricTestRunner() {
 
-    private lateinit var carAppLifecycleOwner: CarAppLifecycleOwner
     private val testLifecycleObserver: DefaultLifecycleObserver = mockk(relaxUnitFun = true)
+    private val carAppLifecycleOwner = CarAppLifecycleOwner()
 
     @Before
     fun setup() {
-        carAppLifecycleOwner = CarAppLifecycleOwner()
         carAppLifecycleOwner.lifecycle.addObserver(testLifecycleObserver)
     }
 

--- a/android-auto/src/test/java/com/mapbox/navigation/lifecycle/MapboxNavigationOwnerTest.kt
+++ b/android-auto/src/test/java/com/mapbox/navigation/lifecycle/MapboxNavigationOwnerTest.kt
@@ -1,0 +1,139 @@
+@file:Suppress("NoMockkVerifyImport")
+
+package com.mapbox.navigation.lifecycle
+
+import android.app.Application
+import androidx.lifecycle.LifecycleOwner
+import com.mapbox.androidauto.testing.CarAppTestRule
+import com.mapbox.navigation.base.options.NavigationOptions
+import com.mapbox.navigation.core.MapboxNavigation
+import com.mapbox.navigation.core.MapboxNavigationProvider
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import io.mockk.verifyOrder
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class MapboxNavigationOwnerTest {
+
+    @get:Rule
+    val carAppTest = CarAppTestRule()
+
+    private val application: Application = mockk()
+    private val mapboxNavigation: MapboxNavigation = mockk()
+    private val navigationOptions: NavigationOptions = mockk {
+        every { accessToken } returns "test_access_token"
+    }
+    private val mapboxNavigationInitializer: MapboxNavigationInitializer = mockk {
+        every { create(any()) } returns navigationOptions
+    }
+
+    private lateinit var mapboxNavigationOwner: MapboxNavigationOwner
+
+    @Before
+    fun setup() {
+        mockkStatic(MapboxNavigationProvider::class)
+        every { MapboxNavigationProvider.create(navigationOptions) } returns mapboxNavigation
+        every { MapboxNavigationProvider.retrieve() } returns mapboxNavigation
+        mapboxNavigationOwner = MapboxNavigationOwner(application, mapboxNavigationInitializer)
+    }
+
+    @After
+    fun teardown() {
+        unmockkStatic(MapboxNavigationProvider::class)
+    }
+
+    @Test
+    fun `full lifecycle will attach and detach MapboxNavigation`() {
+        val mapboxNavigationOwner = MapboxNavigationOwner(application, mapboxNavigationInitializer)
+        val mapboxNavigationObserver = mockk<MapboxNavigationObserver>(relaxUnitFun = true)
+        mapboxNavigationOwner.register(mapboxNavigationObserver)
+
+        val lifecycleOwner: LifecycleOwner = mockk()
+        mapboxNavigationOwner.carAppLifecycleObserver.onCreate(lifecycleOwner)
+        mapboxNavigationOwner.carAppLifecycleObserver.onStart(lifecycleOwner)
+        mapboxNavigationOwner.carAppLifecycleObserver.onResume(lifecycleOwner)
+        mapboxNavigationOwner.carAppLifecycleObserver.onPause(lifecycleOwner)
+        mapboxNavigationOwner.carAppLifecycleObserver.onStop(lifecycleOwner)
+        mapboxNavigationOwner.carAppLifecycleObserver.onDestroy(lifecycleOwner)
+
+        verifyOrder {
+            mapboxNavigationObserver.onAttached(any())
+            mapboxNavigationObserver.onDetached(any())
+        }
+    }
+
+    @Test
+    fun `attach and detach multiple times`() {
+        val mapboxNavigationOwner = MapboxNavigationOwner(application, mapboxNavigationInitializer)
+        val mapboxNavigationObserver = mockk<MapboxNavigationObserver>(relaxUnitFun = true)
+        mapboxNavigationOwner.register(mapboxNavigationObserver)
+
+        val lifecycleOwner: LifecycleOwner = mockk()
+        mapboxNavigationOwner.carAppLifecycleObserver.onStart(lifecycleOwner)
+        mapboxNavigationOwner.carAppLifecycleObserver.onStop(lifecycleOwner)
+        mapboxNavigationOwner.carAppLifecycleObserver.onStart(lifecycleOwner)
+        mapboxNavigationOwner.carAppLifecycleObserver.onStop(lifecycleOwner)
+
+        verifyOrder {
+            mapboxNavigationObserver.onAttached(any())
+            mapboxNavigationObserver.onDetached(any())
+            mapboxNavigationObserver.onAttached(any())
+            mapboxNavigationObserver.onDetached(any())
+        }
+    }
+
+    @Test
+    fun `notify multiple observers in the order they were registered`() {
+        val mapboxNavigationOwner = MapboxNavigationOwner(application, mapboxNavigationInitializer)
+        val firstObserver = mockk<MapboxNavigationObserver>(relaxUnitFun = true)
+        val secondObserver = mockk<MapboxNavigationObserver>(relaxUnitFun = true)
+        mapboxNavigationOwner.register(firstObserver)
+        mapboxNavigationOwner.register(secondObserver)
+
+        val lifecycleOwner: LifecycleOwner = mockk()
+        mapboxNavigationOwner.carAppLifecycleObserver.onStart(lifecycleOwner)
+        mapboxNavigationOwner.carAppLifecycleObserver.onStop(lifecycleOwner)
+
+        verifyOrder {
+            firstObserver.onAttached(any())
+            secondObserver.onAttached(any())
+            firstObserver.onDetached(any())
+            secondObserver.onDetached(any())
+        }
+    }
+
+    @Test
+    fun `attach and detach observer when navigation is started`() {
+        val mapboxNavigationOwner = MapboxNavigationOwner(application, mapboxNavigationInitializer)
+
+        val lifecycleOwner: LifecycleOwner = mockk()
+        mapboxNavigationOwner.carAppLifecycleObserver.onStart(lifecycleOwner)
+
+        val observer = mockk<MapboxNavigationObserver>(relaxUnitFun = true)
+        mapboxNavigationOwner.register(observer)
+        mapboxNavigationOwner.unregister(observer)
+
+        verifyOrder {
+            observer.onAttached(any())
+            observer.onDetached(any())
+        }
+    }
+
+    @Test
+    fun `do not attach and detach null when navigation is stopped`() {
+        val mapboxNavigationOwner = MapboxNavigationOwner(application, mapboxNavigationInitializer)
+
+        val observer = mockk<MapboxNavigationObserver>(relaxUnitFun = true)
+        mapboxNavigationOwner.register(observer)
+        mapboxNavigationOwner.unregister(observer)
+
+        verify(exactly = 0) { observer.onAttached(any()) }
+        verify(exactly = 1) { observer.onDetached(null) }
+    }
+}

--- a/android-auto/src/test/resources/carmen_feature_oakland_coffee.json
+++ b/android-auto/src/test/resources/carmen_feature_oakland_coffee.json
@@ -1,0 +1,59 @@
+{
+  "type": "Feature",
+  "id": "poi.773094129083",
+  "geometry": {
+    "coordinates": [
+      -122.273904,
+      37.800456
+    ],
+    "type": "Point"
+  },
+  "properties": {
+    "foursquare": "4a79c531f964a5209de71fe3",
+    "landmark": true,
+    "address": "801 Broadway",
+    "category": "coffee, cafe"
+  },
+  "text": "Starbucks",
+  "place_name": "Starbucks, 801 Broadway, Oakland, California 94607, United States",
+  "place_type": [
+    "poi"
+  ],
+  "center": [
+    -122.273904,
+    37.800456
+  ],
+  "context": [
+    {
+      "id": "neighborhood.8696440294299070",
+      "text": "Old Oakland"
+    },
+    {
+      "id": "postcode.1556247208801260",
+      "text": "94607"
+    },
+    {
+      "id": "place.8631031862973970",
+      "text": "Oakland",
+      "wikidata": "Q17042"
+    },
+    {
+      "id": "district.11187960009291250",
+      "text": "Alameda County",
+      "wikidata": "Q107146"
+    },
+    {
+      "id": "region.9803118085738010",
+      "text": "California",
+      "short_code": "US-CA",
+      "wikidata": "Q99"
+    },
+    {
+      "id": "country.19678805456372290",
+      "text": "United States",
+      "short_code": "us",
+      "wikidata": "Q30"
+    }
+  ],
+  "relevance": 1.0
+}


### PR DESCRIPTION
## Features

### Navigate with voice commands

- Added `GeoDeeplinkParser` `GeoDeeplinkGeocoding`, `GeoDeeplinkNavigateAction` `GeoDeeplinkPlacesListOnMapProvider`

Google Play was providing a warning that our app does not handle voice commands. So now you can navigate with audio. To test it with the desktop head unit, use the `mic begin` command.

```
./desktop-head-unit
>  mic begin
** speak "Navigate to coffee"
```

https://user-images.githubusercontent.com/3021882/141598723-e8efab90-ffa8-441c-9544-e54052d5816f.mov

## Fixes

#### Show markers and current location place list map view.

| Before | After |
| -- | -- |
| ![Screen Shot 2021-11-11 at 4 32 46 PM](https://user-images.githubusercontent.com/3021882/141388654-6a0e30dc-cedb-4332-bb59-fa85baa9842f.png) | ![Screen Shot 2021-11-11 at 4 49 36 PM](https://user-images.githubusercontent.com/3021882/141389877-8e74d2bb-93c0-4668-ad0a-5043bb408645.png) |

## Refactor

`MapboxNavigationProvider` can have issues because a previous version of `MapboxNavigation` will be destroyed. This results in a common crash "Fatal Exception: java.lang.IllegalStateException: This instance of MapboxNavigation is destroyed." 

Instead of accessing `MapboxNavigation` through `MapboxNavigation.retrieve()`, this is making it so we can access `MapboxNavigation` through services with a lifecycle.

``` kotlin
class MyApplication : Application() {
    override fun onCreate() {
        super.onCreate()

        // Required in order to use `MapboxNavigationApp`
        MapboxNavigationApp.setup(this, MyMapboxNavigationInitializer())

        // Application level services
        MapboxNavigationApp.registerObserver(MyHistoryLifecycleObserver())
        MapboxNavigationApp.registerObserver(MyReplayLifecycleObserver())

        // Setup android auto after you set up MapboxNavigationApp
        MapboxCarApp.setup(this, ExampleCarInitializer())
```

``` kotlin
class MyNavigationInitializer : MapboxNavigationInitializer {
    override fun create(application: Application): NavigationOptions {
        // Allows you to customize `NavigationOptions`
    }
}
```

``` kotlin
class MyHistoryLifecycleObserver : MapboxNavigationObserver {
    private lateinit var history: ExampleHistoryRecorder

    override fun onAttached(mapboxNavigation: MapboxNavigation) {
        history = getKoin().get(ExampleHistoryRecorder::class)
        history.startRecording(mapboxNavigation)
    }

    override fun onDetached(mapboxNavigation: MapboxNavigation?) {
        history.stopAndUploadHistory(mapboxNavigation)
    }
}
```