### PR TITLE
Don't launch examples until access token is provided

### DIFF
--- a/app/src/main/java/com/mapbox/navigation/examples/MainActivity.kt
+++ b/app/src/main/java/com/mapbox/navigation/examples/MainActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Bundle
 import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
@@ -33,6 +34,11 @@ class MainActivity : AppCompatActivity(), PermissionsListener {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        if (!isMapboxTokenProvided()) {
+            showNoTokenErrorDialog()
+            return
+        }
+
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
@@ -178,4 +184,20 @@ class MainActivity : AppCompatActivity(), PermissionsListener {
             ),
         )
     }
+
+    private fun isMapboxTokenProvided() =
+        getString(R.string.mapbox_access_token) != MAPBOX_ACCESS_TOKEN_PLACEHOLDER
+
+    private fun showNoTokenErrorDialog() {
+        AlertDialog.Builder(this)
+            .setTitle(getString(R.string.noTokenDialogTitle))
+            .setMessage(getString(R.string.noTokenDialogBody))
+            .setCancelable(false)
+            .setPositiveButton("Ok") { _, _ ->
+                finish()
+            }
+            .show()
+    }
 }
+
+private const val MAPBOX_ACCESS_TOKEN_PLACEHOLDER = "YOUR_MAPBOX_ACCESS_TOKEN_GOES_HERE"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,9 @@
 <resources>
   <string name="app_name">Mapbox Navigation Examples</string>
 
+  <string name="noTokenDialogTitle">Error: no mapbox access token</string>
+  <string name="noTokenDialogBody">Please put your mapbox access token to res/values/mapbox_access_token.xml</string>
+
   <!-- Fetch Route -->
   <string name="fetch_a_route_message">Route was fetched successfully</string>
   <string name="fetch_a_route_cancel_message">Route request was canceled</string>

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,9 @@ buildscript {
             credentials {
                 username = "mapbox"
                 password = project.hasProperty('MAPBOX_DOWNLOADS_TOKEN') ? project.property('MAPBOX_DOWNLOADS_TOKEN') : System.getenv('MAPBOX_DOWNLOADS_TOKEN')
+                if (password == null || password == "") {
+                    throw new GradleException("MAPBOX_DOWNLOADS_TOKEN isn't set. Set it to the project properties or to the enviroment variables.")
+                }
             }
         }
     }
@@ -34,6 +37,9 @@ allprojects {
             credentials {
                 username = "mapbox"
                 password = project.hasProperty('MAPBOX_DOWNLOADS_TOKEN') ? project.property('MAPBOX_DOWNLOADS_TOKEN') : System.getenv('MAPBOX_DOWNLOADS_TOKEN')
+                if (password == null || password == "") {
+                    throw new GradleException("MAPBOX_DOWNLOADS_TOKEN isn't set. Set it to the project properties or to the enviroment variables.")
+                }
             }
         }
     }


### PR DESCRIPTION
Nobody reads README.me . No access token error dialog will help developer not to miss this important step 