### PR TITLE
Added example demonstrating an arrival experience using route progress

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -57,7 +57,7 @@ android {
 dependencies {
     // Mapbox Navigation SDK
     implementation "com.mapbox.navigation:android:2.2.0"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.21"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.31"
     implementation "androidx.core:core-ktx:1.6.0"
     implementation "com.google.android.material:material:1.4.0"
     implementation "androidx.appcompat:appcompat:1.3.1"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -72,6 +72,11 @@
         android:screenOrientation="portrait"
         android:exported="false"
         />
+
+    <activity android:name=".basics.CustomArrivalActivity"
+        android:screenOrientation="portrait"
+        android:exported="false"
+        />
   </application>
 
 </manifest>

--- a/app/src/main/java/com/mapbox/navigation/examples/MainActivity.kt
+++ b/app/src/main/java/com/mapbox/navigation/examples/MainActivity.kt
@@ -13,6 +13,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.mapbox.android.core.permissions.PermissionsListener
 import com.mapbox.android.core.permissions.PermissionsManager
 import com.mapbox.android.core.permissions.PermissionsManager.areLocationPermissionsGranted
+import com.mapbox.navigation.examples.basics.CustomArrivalActivity
 import com.mapbox.navigation.examples.basics.FetchARouteActivity
 import com.mapbox.navigation.examples.basics.MultipleWaypointsActivity
 import com.mapbox.navigation.examples.basics.PlayVoiceInstructionsActivity
@@ -182,6 +183,15 @@ class MainActivity : AppCompatActivity(), PermissionsListener {
                 getString(R.string.description_multiple_way_points),
                 MultipleWaypointsActivity::class.java
             ),
+            MapboxExample(
+                ContextCompat.getDrawable(
+                    this,
+                    R.drawable.mapbox_screenshot_building_extrusion
+                ),
+                getString(R.string.title_building_extrusions_custom_arrival),
+                getString(R.string.description_building_extrusions_custom_arrival),
+                CustomArrivalActivity::class.java
+            )
         )
     }
 

--- a/app/src/main/res/layout/mapbox_activity_custom_arrival.xml
+++ b/app/src/main/res/layout/mapbox_activity_custom_arrival.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+  <com.mapbox.maps.MapView
+      android:id="@+id/mapView"
+      android:layout_width="0dp"
+      android:layout_height="0dp"
+      app:layout_constraintTop_toTopOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintBottom_toBottomOf="parent" />
+
+  <androidx.appcompat.widget.AppCompatButton
+      android:id="@+id/actionButton"
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      android:padding="12dp"
+      android:textColor="@android:color/white"
+      android:layout_marginEnd="8dp"
+      android:layout_marginStart="8dp"
+      android:layout_marginBottom="8dp"
+      android:textAllCaps="false"
+      android:visibility="gone"
+      android:background="@drawable/mapbox_button"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintBottom_toBottomOf="parent"
+      />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,4 +54,8 @@
   <string name="waypoint_type_regular">Regular</string>
   <string name="waypoint_type_named">Named</string>
   <string name="waypoint_type_silent">Silent</string>
+
+  <!-- Custom Arrival Building Extrusions -->
+  <string name="title_building_extrusions_custom_arrival">Render building extrusion based on custom arrival criteria.</string>
+  <string name="description_building_extrusions_custom_arrival">Use the example to render building extrusions on arrival using building API and MapboxBuildingView.</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.0.3'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31"
         classpath "com.mapbox.gradle.plugins:access-token:0.2.1"
     }
 }

--- a/gradle/script-git-version.gradle
+++ b/gradle/script-git-version.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'org.ajoberstar.grgit:grgit-core:4.1.0'
+        classpath 'org.ajoberstar.grgit:grgit-core:4.1.1'
     }
 }
 


### PR DESCRIPTION
Resolves #63 by creating an example activity that demonstrates creating a custom arrival experience using the RouteProgress rather than the ArrivalObserver.  