### PR TITLE
Migration from `MapboxNavigationProvider` to `MapboxNavigationApp`

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -69,7 +69,7 @@ android {
 
 dependencies {
     // Mapbox Navigation SDK
-    implementation "com.mapbox.navigation:android:2.5.1"
+    implementation "com.mapbox.navigation:android:2.8.0-alpha.2"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.31"
     implementation "androidx.core:core-ktx:1.7.0"
     implementation "com.google.android.material:material:1.5.0"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -69,7 +69,7 @@ android {
 
 dependencies {
     // Mapbox Navigation SDK
-    implementation "com.mapbox.navigation:android:2.8.0-alpha.2"
+    implementation "com.mapbox.navigation:android:2.8.0-alpha.3"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.31"
     implementation "androidx.core:core-ktx:1.7.0"
     implementation "com.google.android.material:material:1.5.0"

--- a/app/src/main/java/com/mapbox/navigation/examples/MainActivity.kt
+++ b/app/src/main/java/com/mapbox/navigation/examples/MainActivity.kt
@@ -29,9 +29,6 @@ class MainActivity : AppCompatActivity(), PermissionsListener {
             return
         }
 
-        // Each example needs to call MapboxNavigationApp.setup.
-        MapboxNavigationApp.disable()
-
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
@@ -42,6 +39,12 @@ class MainActivity : AppCompatActivity(), PermissionsListener {
         }
 
         bindExamples()
+    }
+
+    override fun onStart() {
+        super.onStart()
+        // Each example is responsible for setting up their NavigationOptions.
+        MapboxNavigationApp.disable()
     }
 
     override fun onExplanationNeeded(permissionsToExplain: MutableList<String>?) {

--- a/app/src/main/java/com/mapbox/navigation/examples/MainActivity.kt
+++ b/app/src/main/java/com/mapbox/navigation/examples/MainActivity.kt
@@ -13,6 +13,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.mapbox.android.core.permissions.PermissionsListener
 import com.mapbox.android.core.permissions.PermissionsManager
 import com.mapbox.android.core.permissions.PermissionsManager.areLocationPermissionsGranted
+import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
 import com.mapbox.navigation.examples.databinding.ActivityMainBinding
 
 class MainActivity : AppCompatActivity(), PermissionsListener {
@@ -27,6 +28,9 @@ class MainActivity : AppCompatActivity(), PermissionsListener {
             showNoTokenErrorDialog()
             return
         }
+
+        // Each example needs to call MapboxNavigationApp.setup.
+        MapboxNavigationApp.disable()
 
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)

--- a/app/src/main/java/com/mapbox/navigation/examples/alternative/ShowAlternativeRoutesActivity.kt
+++ b/app/src/main/java/com/mapbox/navigation/examples/alternative/ShowAlternativeRoutesActivity.kt
@@ -6,8 +6,6 @@ import android.location.Location
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
-import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.geojson.Point

--- a/app/src/main/java/com/mapbox/navigation/examples/alternative/ShowAlternativeRoutesActivity.kt
+++ b/app/src/main/java/com/mapbox/navigation/examples/alternative/ShowAlternativeRoutesActivity.kt
@@ -254,7 +254,7 @@ class ShowAlternativeRoutesActivity : AppCompatActivity() {
         }
     }
 
-    val navigationResumedObserver = object : MapboxNavigationObserver {
+    private val navigationResumedObserver = object : MapboxNavigationObserver {
         override fun onAttached(mapboxNavigation: MapboxNavigation) {
             mapboxNavigation.registerLocationObserver(locationObserver)
             mapboxNavigation.registerRouteProgressObserver(replayProgressObserver)
@@ -274,7 +274,7 @@ class ShowAlternativeRoutesActivity : AppCompatActivity() {
 
     init {
         // You can setup MapboxNavigation at any part of the app lifecycle.
-        MapboxNavigationApp.setup(
+        MapboxNavigationApp.setup {
             NavigationOptions.Builder(this)
                 .accessToken(getString(R.string.mapbox_access_token))
                 .locationEngine(ReplayLocationEngine(mapboxReplayer))
@@ -284,25 +284,7 @@ class ShowAlternativeRoutesActivity : AppCompatActivity() {
                         .build()
                 )
                 .build()
-        ).attach(this)
-
-        lifecycle.addObserver(object : DefaultLifecycleObserver {
-            override fun onCreate(owner: LifecycleOwner) {
-                MapboxNavigationApp.registerObserver(navigationCreatedObserver)
-            }
-
-            override fun onResume(owner: LifecycleOwner) {
-                MapboxNavigationApp.registerObserver(navigationResumedObserver)
-            }
-
-            override fun onPause(owner: LifecycleOwner) {
-                MapboxNavigationApp.unregisterObserver(navigationResumedObserver)
-            }
-
-            override fun onDestroy(owner: LifecycleOwner) {
-                MapboxNavigationApp.unregisterObserver(navigationCreatedObserver)
-            }
-        })
+        }.attach(this)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -322,11 +304,23 @@ class ShowAlternativeRoutesActivity : AppCompatActivity() {
             findRoute(originPoint, destinationPoint)
         }
 
+        MapboxNavigationApp.registerObserver(navigationCreatedObserver)
         replayOriginLocation()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        MapboxNavigationApp.registerObserver(navigationResumedObserver)
+    }
+
+    override fun onPause() {
+        super.onPause()
+        MapboxNavigationApp.unregisterObserver(navigationResumedObserver)
     }
 
     override fun onDestroy() {
         super.onDestroy()
+        MapboxNavigationApp.unregisterObserver(navigationCreatedObserver)
         routeLineApi.cancel()
         routeLineView.cancel()
         mapboxReplayer.finish()

--- a/app/src/main/java/com/mapbox/navigation/examples/alternative/ShowAlternativeRoutesActivity.kt
+++ b/app/src/main/java/com/mapbox/navigation/examples/alternative/ShowAlternativeRoutesActivity.kt
@@ -6,6 +6,8 @@ import android.location.Location
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.geojson.Point
@@ -26,8 +28,9 @@ import com.mapbox.navigation.base.route.RouterFailure
 import com.mapbox.navigation.base.route.RouterOrigin
 import com.mapbox.navigation.base.trip.model.RouteProgress
 import com.mapbox.navigation.core.MapboxNavigation
-import com.mapbox.navigation.core.MapboxNavigationProvider
 import com.mapbox.navigation.core.directions.session.RoutesObserver
+import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
+import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
 import com.mapbox.navigation.core.replay.MapboxReplayer
 import com.mapbox.navigation.core.replay.ReplayLocationEngine
 import com.mapbox.navigation.core.replay.route.ReplayProgressObserver
@@ -240,13 +243,38 @@ class ShowAlternativeRoutesActivity : AppCompatActivity() {
     }
 
     @SuppressLint("MissingPermission")
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        binding = ActivityShowAlternativeRoutesBinding.inflate(layoutInflater)
-        setContentView(binding.root)
+    val navigationCreatedObserver = object : MapboxNavigationObserver {
+        override fun onAttached(mapboxNavigation: MapboxNavigation) {
+            this@ShowAlternativeRoutesActivity.mapboxNavigation = mapboxNavigation
+            mapboxNavigation.startTripSession()
+        }
 
-        // initialize Mapbox Navigation
-        mapboxNavigation = MapboxNavigationProvider.create(
+        override fun onDetached(mapboxNavigation: MapboxNavigation) {
+            // mapboxNavigation is invalid
+        }
+    }
+
+    val navigationResumedObserver = object : MapboxNavigationObserver {
+        override fun onAttached(mapboxNavigation: MapboxNavigation) {
+            mapboxNavigation.registerLocationObserver(locationObserver)
+            mapboxNavigation.registerRouteProgressObserver(replayProgressObserver)
+            mapboxNavigation.registerRoutesObserver(routesObserver)
+            mapboxNavigation.registerRouteAlternativesObserver(alternativesObserver)
+            binding.mapView.gestures.addOnMapClickListener(mapClickListener)
+        }
+
+        override fun onDetached(mapboxNavigation: MapboxNavigation) {
+            mapboxNavigation.unregisterRouteProgressObserver(replayProgressObserver)
+            mapboxNavigation.unregisterLocationObserver(locationObserver)
+            mapboxNavigation.unregisterRoutesObserver(routesObserver)
+            mapboxNavigation.unregisterRouteAlternativesObserver(alternativesObserver)
+            binding.mapView.gestures.removeOnMapClickListener(mapClickListener)
+        }
+    }
+
+    init {
+        // You can setup MapboxNavigation at any part of the app lifecycle.
+        MapboxNavigationApp.setup(
             NavigationOptions.Builder(this)
                 .accessToken(getString(R.string.mapbox_access_token))
                 .locationEngine(ReplayLocationEngine(mapboxReplayer))
@@ -256,7 +284,31 @@ class ShowAlternativeRoutesActivity : AppCompatActivity() {
                         .build()
                 )
                 .build()
-        )
+        ).attach(this)
+
+        lifecycle.addObserver(object : DefaultLifecycleObserver {
+            override fun onCreate(owner: LifecycleOwner) {
+                MapboxNavigationApp.registerObserver(navigationCreatedObserver)
+            }
+
+            override fun onResume(owner: LifecycleOwner) {
+                MapboxNavigationApp.registerObserver(navigationResumedObserver)
+            }
+
+            override fun onPause(owner: LifecycleOwner) {
+                MapboxNavigationApp.unregisterObserver(navigationResumedObserver)
+            }
+
+            override fun onDestroy(owner: LifecycleOwner) {
+                MapboxNavigationApp.unregisterObserver(navigationCreatedObserver)
+            }
+        })
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityShowAlternativeRoutesBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
         binding.mapView.getMapboxMap().loadStyleUri(
             NavigationStyles.NAVIGATION_DAY_STYLE
@@ -270,25 +322,7 @@ class ShowAlternativeRoutesActivity : AppCompatActivity() {
             findRoute(originPoint, destinationPoint)
         }
 
-        binding.mapView.gestures.addOnMapClickListener(mapClickListener)
         replayOriginLocation()
-        mapboxNavigation.startTripSession()
-    }
-
-    override fun onStart() {
-        super.onStart()
-        mapboxNavigation.registerLocationObserver(locationObserver)
-        mapboxNavigation.registerRouteProgressObserver(replayProgressObserver)
-        mapboxNavigation.registerRoutesObserver(routesObserver)
-        mapboxNavigation.registerRouteAlternativesObserver(alternativesObserver)
-    }
-
-    override fun onStop() {
-        super.onStop()
-        mapboxNavigation.unregisterRouteProgressObserver(replayProgressObserver)
-        mapboxNavigation.unregisterLocationObserver(locationObserver)
-        mapboxNavigation.unregisterRoutesObserver(routesObserver)
-        mapboxNavigation.unregisterRouteAlternativesObserver(alternativesObserver)
     }
 
     override fun onDestroy() {
@@ -296,7 +330,6 @@ class ShowAlternativeRoutesActivity : AppCompatActivity() {
         routeLineApi.cancel()
         routeLineView.cancel()
         mapboxReplayer.finish()
-        mapboxNavigation.onDestroy()
     }
 
     /**

--- a/app/src/main/java/com/mapbox/navigation/examples/junctions/ShowJunctionsActivity.kt
+++ b/app/src/main/java/com/mapbox/navigation/examples/junctions/ShowJunctionsActivity.kt
@@ -230,7 +230,7 @@ class ShowJunctionsActivity : AppCompatActivity() {
 
 fun AppCompatActivity.mapboxNavigationInstaller() = MapboxNavigationActivityInstaller(this)
 
-fun mapboxLocationObserver(locationObserver: LocationObserver) : MapboxNavigationObserver {
+fun mapboxLocationObserver(locationObserver: LocationObserver): MapboxNavigationObserver {
     return object : MapboxNavigationObserver {
         override fun onAttached(mapboxNavigation: MapboxNavigation) {
             mapboxNavigation.registerLocationObserver(locationObserver)
@@ -242,7 +242,7 @@ fun mapboxLocationObserver(locationObserver: LocationObserver) : MapboxNavigatio
     }
 }
 
-fun mapboxRoutesObserver(routesObserver: RoutesObserver) : MapboxNavigationObserver {
+fun mapboxRoutesObserver(routesObserver: RoutesObserver): MapboxNavigationObserver {
     return object : MapboxNavigationObserver {
         override fun onAttached(mapboxNavigation: MapboxNavigation) {
             mapboxNavigation.registerRoutesObserver(routesObserver)
@@ -254,7 +254,7 @@ fun mapboxRoutesObserver(routesObserver: RoutesObserver) : MapboxNavigationObser
     }
 }
 
-fun mapboxBannerInstructionsObserver(bannerInstructionsObserver: BannerInstructionsObserver) : MapboxNavigationObserver {
+fun mapboxBannerInstructionsObserver(bannerInstructionsObserver: BannerInstructionsObserver): MapboxNavigationObserver {
     return object : MapboxNavigationObserver {
         override fun onAttached(mapboxNavigation: MapboxNavigation) {
             mapboxNavigation.registerBannerInstructionsObserver(bannerInstructionsObserver)
@@ -266,7 +266,7 @@ fun mapboxBannerInstructionsObserver(bannerInstructionsObserver: BannerInstructi
     }
 }
 
-fun mapboxRouteProgressObserver(routeProgressObserver: RouteProgressObserver) : MapboxNavigationObserver {
+fun mapboxRouteProgressObserver(routeProgressObserver: RouteProgressObserver): MapboxNavigationObserver {
     return object : MapboxNavigationObserver {
         override fun onAttached(mapboxNavigation: MapboxNavigation) {
             mapboxNavigation.registerRouteProgressObserver(routeProgressObserver)

--- a/app/src/main/java/com/mapbox/navigation/examples/location/ShowCurrentLocationActivity.kt
+++ b/app/src/main/java/com/mapbox/navigation/examples/location/ShowCurrentLocationActivity.kt
@@ -5,7 +5,6 @@ import android.location.Location
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import com.mapbox.geojson.Point
 import com.mapbox.maps.CameraOptions
@@ -18,8 +17,6 @@ import com.mapbox.maps.plugin.animation.camera
 import com.mapbox.maps.plugin.locationcomponent.location
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.core.MapboxNavigation
-import com.mapbox.navigation.core.MapboxNavigationProvider
-import com.mapbox.navigation.core.internal.extensions.attachCreated
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
 import com.mapbox.navigation.core.trip.session.LocationMatcherResult


### PR DESCRIPTION
Resolves https://github.com/mapbox/mapbox-navigation-android-examples/issues/128

## Some initial ideas

I migrated `ShowAlternativeRoutesActivity` to the non-experimental apis to get a feel for how the migration will go. I think we should define some extensions because there is a lot of boilerplate.

If we defined `MapboxNavigationApp` extensions inside the core sdk, that could make it nicer. So I added an idea to the `ShowCurrentLocationActivity` example. This way your `init` function looks something like this? Just an idea.

``` kotlin
    init {
        MapboxNavigationApp.setup(
            NavigationOptions.Builder(this)
                .accessToken(getString(R.string.mapbox_access_token))
                .build()
        ).attach(this)

        MapboxNavigationApp.attach(
            this,
            onResume = { registerLocationObserver(locationObserver) },
            onPause = { unregisterLocationObserver(locationObserver) },
        )
    }
```