### PR TITLE
request WRITE_EXTERNAL_STORAGE only until Android R

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ apply from: "${rootDir}/gradle/script-git-version.gradle"
 apply from: "${rootDir}/gradle/ktlint.gradle"
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -15,7 +15,7 @@ android {
     defaultConfig {
         applicationId "com.mapbox.navigation.examples"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 33
         multiDexEnabled true
         versionCode gitNumberOfCommits
         versionName gitTagDescription

--- a/app/src/main/java/com/mapbox/navigation/examples/MainActivity.kt
+++ b/app/src/main/java/com/mapbox/navigation/examples/MainActivity.kt
@@ -3,6 +3,7 @@ package com.mapbox.navigation.examples
 import android.Manifest
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
@@ -32,7 +33,7 @@ class MainActivity : AppCompatActivity(), PermissionsListener {
         setContentView(binding.root)
 
         if (areLocationPermissionsGranted(this)) {
-            requestStoragePermission()
+            maybeRequestStoragePermission()
         } else {
             permissionsManager.requestLocationPermissions(this)
         }
@@ -50,7 +51,7 @@ class MainActivity : AppCompatActivity(), PermissionsListener {
 
     override fun onPermissionResult(granted: Boolean) {
         if (granted) {
-            requestStoragePermission()
+            maybeRequestStoragePermission()
         } else {
             Toast.makeText(
                 this,
@@ -69,7 +70,11 @@ class MainActivity : AppCompatActivity(), PermissionsListener {
         permissionsManager.onRequestPermissionsResult(requestCode, permissions, grantResults)
     }
 
-    private fun requestStoragePermission() {
+    private fun maybeRequestStoragePermission() {
+        // starting from Android R leak canary writes to Download storage without the permission
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            return
+        }
         val permission = Manifest.permission.WRITE_EXTERNAL_STORAGE
         val permissionsNeeded: MutableList<String> = ArrayList()
         if (

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.3'
+        classpath 'com.android.tools.build:gradle:7.2.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31"
         classpath "com.mapbox.gradle.plugins:access-token:0.2.1"
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip


### PR DESCRIPTION
Refs https://github.com/mapbox/mapbox-navigation-android/issues/6195.

# Description

The permission only appears in the Manifest because of the leakcanary library. According to [their docs](https://square.github.io/leakcanary/faq/#where-does-leakcanary-store-heap-dumps), it's required to store heap dumps in the Download folder. But they will be stored in the app directory if the permission has not been granted. However, they support writing to Download folder without the permission starting from Android R.