### PR TITLE
Fix arrival car app sync

### DIFF
--- a/android-auto-app/src/main/java/com/mapbox/navigation/examples/androidauto/CarAppSyncComponent.kt
+++ b/android-auto-app/src/main/java/com/mapbox/navigation/examples/androidauto/CarAppSyncComponent.kt
@@ -168,7 +168,8 @@ class CarAppSyncComponent private constructor() : MapboxNavigationObserver {
             }
             ArrivalState -> {
                 logI(LOG_TAG, "navigationView.api.startArrival()")
-                navigationView.api.startArrival()
+                val routes = MapboxNavigationApp.current()!!.getNavigationRoutes()
+                navigationView.api.startArrival(routes)
             }
         }
     }


### PR DESCRIPTION
@Zayankovsky found another issue https://github.com/mapbox/mapbox-navigation-android-examples/pull/148/files#r975141161

This seems like it is also an issue with the navigation view initialization 🤔 . 

`MapboxNavigation.routes` should be used by the `NavigationView`