### PR TITLE
Upgrade AAOS to 0.12.0

### DIFF
--- a/android-automotive-app/build.gradle
+++ b/android-automotive-app/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     implementation "androidx.fragment:fragment-ktx:1.4.1"
 
     // Mapbox Navigation Android Auto SDK Developer Preview
-    implementation("com.mapbox.navigation:ui-androidauto:0.8.0")
+    implementation("com.mapbox.navigation:ui-androidauto:0.12.0")
 
     // Android Automotive library
     // https://developer.android.com/jetpack/androidx/releases/car-app

--- a/android-automotive-app/src/main/java/com/mapbox/navigation/examples/aaos/ExampleApplication.kt
+++ b/android-automotive-app/src/main/java/com/mapbox/navigation/examples/aaos/ExampleApplication.kt
@@ -1,25 +1,19 @@
 package com.mapbox.navigation.examples.aaos
 
 import android.app.Application
-import com.mapbox.androidauto.MapboxCarApp
-import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
 
-@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
 class ExampleApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
 
-        // Setup MapboxNavigation
+        // Set up MapboxNavigation
         MapboxNavigationApp.setup(
             NavigationOptions.Builder(applicationContext)
                 .accessToken(getString(R.string.mapbox_access_token))
                 .build()
         ).attachAllActivities(this)
-
-        // Setup android auto
-        MapboxCarApp.setup(this)
     }
 }

--- a/android-automotive-app/src/main/java/com/mapbox/navigation/examples/aaos/car/MainCarSession.kt
+++ b/android-automotive-app/src/main/java/com/mapbox/navigation/examples/aaos/car/MainCarSession.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.mapbox.android.core.permissions.PermissionsManager
+import com.mapbox.androidauto.MapboxCarApp
 import com.mapbox.androidauto.MapboxCarNavigationManager
 import com.mapbox.androidauto.car.MainCarContext
 import com.mapbox.androidauto.car.MainScreenManager
@@ -23,24 +24,23 @@ import com.mapbox.androidauto.internal.logAndroidAuto
 import com.mapbox.maps.MapInitOptions
 import com.mapbox.maps.MapboxExperimental
 import com.mapbox.maps.extension.androidauto.MapboxCarMap
-import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
 import kotlinx.coroutines.launch
 
-@OptIn(MapboxExperimental::class, ExperimentalPreviewMapboxNavigationAPI::class)
+@OptIn(MapboxExperimental::class)
 class MainCarSession : Session() {
 
     private var mainCarContext: MainCarContext? = null
     private lateinit var mainScreenManager: MainScreenManager
-    private lateinit var mapboxCarMap: MapboxCarMap
     private lateinit var navigationManager: MapboxCarNavigationManager
     private lateinit var carStartTripSession: CarStartTripSession
     private val mainCarMapLoader = MainCarMapLoader()
     private val carLocationPermissions = CarLocationPermissions()
+    private val mapboxCarMap = MapboxCarMap()
 
     init {
         MapboxNavigationApp.attach(this)
-
+        MapboxCarApp.setup()
         val logoSurfaceRenderer = CarLogoSurfaceRenderer()
         val compassSurfaceRenderer = CarCompassSurfaceRenderer()
         logAndroidAuto("MainCarSession constructor")
@@ -54,7 +54,7 @@ class MainCarSession : Session() {
                     context = carContext,
                     styleUri = mainCarMapLoader.mapStyleUri(carContext.isDarkMode)
                 )
-                mapboxCarMap = MapboxCarMap(mapInitOptions)
+                mapboxCarMap.setup(carContext, mapInitOptions)
                 mainCarContext = MainCarContext(carContext, mapboxCarMap)
                 mainScreenManager = MainScreenManager(mainCarContext!!)
                 navigationManager = MapboxCarNavigationManager(carContext)


### PR DESCRIPTION
Similar to this one https://github.com/mapbox/mapbox-navigation-android-examples/pull/153

External contributions are not kicking of CI/CD jobs for security reasons. So am making the change here.

Also, `ui-androidauto:0.12.0` is incompatible existing `ui-dropin` versions. It requires an upgrade `to ui-dropin:2.9.0-alpha.4` which is not released yet.

But we are able to update the AAOS to `ui-androidauto:0.12.0`. It is good to go!