### PR TITLE
[Android Auto] Bump ui-androidauto to 0.17.1

### DIFF
--- a/android-auto-app/build.gradle
+++ b/android-auto-app/build.gradle
@@ -55,6 +55,6 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.5.1")
 
     // Mapbox Navigation Android Auto SDK Developer Preview
-    implementation("com.mapbox.navigation:ui-androidauto:0.16.0")
-    implementation("com.mapbox.navigation:ui-dropin:2.9.0-rc.2")
+    implementation("com.mapbox.navigation:ui-androidauto:0.17.1")
+    implementation("com.mapbox.navigation:ui-dropin:2.9.3")
 }

--- a/android-auto-app/src/main/AndroidManifest.xml
+++ b/android-auto-app/src/main/AndroidManifest.xml
@@ -20,6 +20,10 @@
             </intent-filter>
         </activity>
 
+        <meta-data
+            android:name="com.google.android.gms.car.application"
+            android:resource="@xml/automotive_app_desc" />
+
         <service
             android:name=".car.MainCarAppService"
             android:exported="true"

--- a/android-auto-app/src/main/java/com/mapbox/navigation/examples/androidauto/CarAppSyncComponent.kt
+++ b/android-auto-app/src/main/java/com/mapbox/navigation/examples/androidauto/CarAppSyncComponent.kt
@@ -8,7 +8,6 @@ import com.mapbox.androidauto.screenmanager.MapboxScreen
 import com.mapbox.androidauto.screenmanager.MapboxScreenEvent
 import com.mapbox.androidauto.screenmanager.MapboxScreenManager
 import com.mapbox.maps.logI
-import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationApp
 import com.mapbox.navigation.core.lifecycle.MapboxNavigationObserver
@@ -18,7 +17,6 @@ import com.mapbox.navigation.ui.base.lifecycle.UIComponent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 
 /**
@@ -27,7 +25,6 @@ import kotlinx.coroutines.launch
  * The libraries are defining public apis so that there can be options to determine the experience
  * while both the car and phone are displayed.
  */
-@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
 class CarAppSyncComponent private constructor() : MapboxNavigationObserver {
 
     private var navigationView: NavigationView? = null

--- a/android-auto-app/src/main/java/com/mapbox/navigation/examples/androidauto/app/MainActivity.kt
+++ b/android-auto-app/src/main/java/com/mapbox/navigation/examples/androidauto/app/MainActivity.kt
@@ -3,11 +3,9 @@ package com.mapbox.navigation.examples.androidauto.app
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.examples.androidauto.CarAppSyncComponent
 import com.mapbox.navigation.examples.androidauto.databinding.MapboxActivityNavigationViewBinding
 
-@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
 class MainActivity : AppCompatActivity() {
     private lateinit var binding: MapboxActivityNavigationViewBinding
 

--- a/android-automotive-app/build.gradle
+++ b/android-automotive-app/build.gradle
@@ -55,9 +55,9 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.5.1")
 
     // Mapbox Navigation Android Auto SDK Developer Preview
-    implementation("com.mapbox.navigation:ui-androidauto:0.16.0")
+    implementation("com.mapbox.navigation:ui-androidauto:0.17.1")
 
     // Android Automotive library
     // https://developer.android.com/jetpack/androidx/releases/car-app
-    implementation("androidx.car.app:app-automotive:1.1.0")
+    implementation("androidx.car.app:app-automotive:1.2.0")
 }

--- a/android-automotive-app/src/main/AndroidManifest.xml
+++ b/android-automotive-app/src/main/AndroidManifest.xml
@@ -22,6 +22,10 @@
             <meta-data android:name="distractionOptimized" android:value="true"/>
         </activity>
 
+        <meta-data
+            android:name="com.android.automotive"
+            android:resource="@xml/automotive_app_desc" />
+
         <service
             android:name=".car.MainCarAppService"
             android:exported="true"

--- a/android-automotive-app/src/main/java/com/mapbox/navigation/examples/aaos/car/CarTripSessionManager.kt
+++ b/android-automotive-app/src/main/java/com/mapbox/navigation/examples/aaos/car/CarTripSessionManager.kt
@@ -4,14 +4,12 @@ import android.annotation.SuppressLint
 import androidx.car.app.CarContext
 import com.mapbox.androidauto.MapboxCarContext
 import com.mapbox.androidauto.internal.logAndroidAuto
-import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.core.MapboxNavigation
 import com.mapbox.navigation.ui.base.lifecycle.UIComponent
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalPreviewMapboxNavigationAPI::class)
 class CarTripSessionManager(
     private val mapboxCarContext: MapboxCarContext
 ) : UIComponent() {


### PR DESCRIPTION
In order to release an AAOS app to Google Play you will need to specify the correct `<meta-data>` in the `AndroidManifest.xml`.

https://github.com/mapbox/mapbox-navigation-android/pull/6676
https://github.com/mapbox/mapbox-navigation-android/pull/6679

Updating the examples to reflect the latest changes introduced in [androidauto-v0.17.1](https://github.com/mapbox/mapbox-navigation-android/releases/tag/androidauto-v0.17.1)

Thanks @jvanderwee + @narko !!

Other changes
 - Using the latest stable `implementation("androidx.car.app:app-automotive:1.2.0")`
 - Using the `mapboxMapInstaller` as we will likely remove the experimental annotation 