### PR TITLE
[Android Auto] Fix issue syncing set route

### DIFF
--- a/android-auto-app/src/main/java/com/mapbox/navigation/examples/androidauto/CarAppSyncComponent.kt
+++ b/android-auto-app/src/main/java/com/mapbox/navigation/examples/androidauto/CarAppSyncComponent.kt
@@ -76,11 +76,6 @@ class CarAppSyncComponent private constructor() : MapboxNavigationObserver {
             }
         }
 
-        override fun onDestinationPreview() {
-            logI(LOG_TAG, "updateCarAppState onDestinationPreview")
-            MapboxScreenManager.replaceTop(MapboxScreen.FREE_DRIVE)
-        }
-
         override fun onRoutePreview() {
             logI(LOG_TAG, "updateCarAppState onRoutePreview")
             MapboxScreenManager.replaceTop(MapboxScreen.ROUTE_PREVIEW)


### PR DESCRIPTION
@tomaszrybakiewicz found this issue in the [main repository example](https://github.com/mapbox/mapbox-navigation-android/pull/6753#issuecomment-1355637838) so i'm also fixing here

1. Open car head unit
2. Open mobile app
3. Set destination in mobile app
4. Notice that the destination cannot be set and it is cleared.

This causes AA to go into FreeDrive and then AA tells DropInUi to go back to FreeDrive. That clears the destination that was just set. 

Simple fix, don't change the AA state based on the DestinationPreview state