### PR TITLE
Example of walking path to the destination [DO NOT MERGE]

### DIFF
--- a/app/src/main/java/com/mapbox/navigation/examples/turnbyturn/TurnByTurnExperienceActivity.kt
+++ b/app/src/main/java/com/mapbox/navigation/examples/turnbyturn/TurnByTurnExperienceActivity.kt
@@ -14,6 +14,7 @@ import com.mapbox.api.directions.v5.models.Bearing
 import com.mapbox.api.directions.v5.models.RouteOptions
 import com.mapbox.bindgen.Expected
 import com.mapbox.geojson.Feature
+import com.mapbox.geojson.FeatureCollection
 import com.mapbox.geojson.LineString
 import com.mapbox.geojson.Point
 import com.mapbox.geojson.utils.PolylineUtils
@@ -749,9 +750,12 @@ class TurnByTurnExperienceActivity : AppCompatActivity() {
     }
 
     private fun updateWalkingLineSource(walkingPathGeometry: List<Point>) {
+        val features: FeatureCollection = if (walkingPathGeometry.isEmpty()) {
+            FeatureCollection.fromFeatures(listOf())
+        } else FeatureCollection.fromFeature(Feature.fromGeometry(LineString.fromLngLats(walkingPathGeometry)))
         binding.mapView.getMapboxMap().getStyle()?.let { style ->
             style.getSourceAs<GeoJsonSource>(WALKING_ROUTE_SOURCE_ID)
-                ?.feature(Feature.fromGeometry(LineString.fromLngLats(walkingPathGeometry)))
+                ?.featureCollection(features)
         }
     }
 }


### PR DESCRIPTION
I updated full turn-by-turn example to demonstrate how walking path could be rendered between the place you leave the car and your real destination. I hope this diff can inspire somebody to implement this feature. However there are some `TODO`s indicating that this example should be updated before real production use, treat it more as an idea. 

I used maps example for inspiration: https://docs.mapbox.com/android/maps/examples/draw-geo-json-line/


https://user-images.githubusercontent.com/6190346/221640388-8eeb25e2-a2c5-4416-93be-1262e7bd19e8.mp4

