### PR TITLE
Registered the voice instructions observer in onAttached.

### DIFF
--- a/app/src/main/java/com/mapbox/navigation/examples/standalone/turnbyturn/TurnByTurnExperienceActivity.kt
+++ b/app/src/main/java/com/mapbox/navigation/examples/standalone/turnbyturn/TurnByTurnExperienceActivity.kt
@@ -403,6 +403,7 @@ class TurnByTurnExperienceActivity : AppCompatActivity() {
                 mapboxNavigation.registerRoutesObserver(routesObserver)
                 mapboxNavigation.registerLocationObserver(locationObserver)
                 mapboxNavigation.registerRouteProgressObserver(routeProgressObserver)
+                mapboxNavigation.registerVoiceInstructionsObserver(voiceInstructionsObserver)
 
                 replayProgressObserver = ReplayProgressObserver(mapboxNavigation.mapboxReplayer)
                 mapboxNavigation.registerRouteProgressObserver(replayProgressObserver)


### PR DESCRIPTION
Registered the voice instructions observer in onAttached in `TurnByTurnExperienceActivity`. It was missing and voice instructions were not working.