### PR TITLE
Add real-time MPH/KPH toggle to Render Speed Limit for a route sample (nav)

### DIFF
--- a/app/src/main/java/com/mapbox/navigation/examples/standalone/speedlimit/ShowSpeedLimitActivity.kt
+++ b/app/src/main/java/com/mapbox/navigation/examples/standalone/speedlimit/ShowSpeedLimitActivity.kt
@@ -17,6 +17,7 @@ import com.mapbox.navigation.base.ExperimentalPreviewMapboxNavigationAPI
 import com.mapbox.navigation.base.extensions.applyDefaultNavigationOptions
 import com.mapbox.navigation.base.extensions.applyLanguageAndVoiceUnitOptions
 import com.mapbox.navigation.base.formatter.DistanceFormatterOptions
+import com.mapbox.navigation.base.formatter.UnitType
 import com.mapbox.navigation.base.options.NavigationOptions
 import com.mapbox.navigation.base.route.NavigationRoute
 import com.mapbox.navigation.base.route.NavigationRouterCallback
@@ -135,9 +136,9 @@ class ShowSpeedLimitActivity : AppCompatActivity() {
      * Options used for formatting speed information, such as mph or km/h.
      * By default, the unit type will be determined based on the device's locale.
      */
-    private val distanceFormatterOptions: DistanceFormatterOptions by lazy {
-        DistanceFormatterOptions.Builder(applicationContext).build()
-    }
+    private lateinit var distanceFormatterOptions: DistanceFormatterOptions
+
+    private var lastLocationMatcherResult: LocationMatcherResult? = null
 
     /**
      * Gets notified with location updates.
@@ -160,6 +161,7 @@ class ShowSpeedLimitActivity : AppCompatActivity() {
          * map-matched to the road if possible.
          */
         override fun onNewLocationMatcherResult(locationMatcherResult: LocationMatcherResult) {
+            lastLocationMatcherResult = locationMatcherResult
             val enhancedLocation = locationMatcherResult.enhancedLocation
             navigationLocationProvider.changePosition(
                 enhancedLocation,
@@ -174,16 +176,20 @@ class ShowSpeedLimitActivity : AppCompatActivity() {
                 enhancedLocation.bearing
             )
 
-            val info = speedInfoApi.updatePostedAndCurrentSpeed(
-                locationMatcherResult,
-                distanceFormatterOptions
-            )
-            if (info != null) {
-                binding.speedLimitView.isVisible = true
-                binding.speedLimitView.render(info)
-            } else {
-                binding.speedLimitView.isVisible = false
-            }
+            updateSpeedLimit(locationMatcherResult)
+        }
+    }
+
+    private fun updateSpeedLimit(locationMatcherResult: LocationMatcherResult) {
+        val info = speedInfoApi.updatePostedAndCurrentSpeed(
+            locationMatcherResult,
+            distanceFormatterOptions
+        )
+        if (info != null) {
+            binding.speedLimitView.isVisible = true
+            binding.speedLimitView.render(info)
+        } else {
+            binding.speedLimitView.isVisible = false
         }
     }
 
@@ -231,11 +237,24 @@ class ShowSpeedLimitActivity : AppCompatActivity() {
         binding = MapboxActivityShowSpeedLimitBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
+        distanceFormatterOptions = DistanceFormatterOptions.Builder(applicationContext).build()
+
+        binding.actionButton.isVisible = true
+        binding.actionButton.setOnClickListener {
+            fetchRoute()
+        }
+
         binding.mapView.mapboxMap.loadStyle(NavigationStyles.NAVIGATION_DAY_STYLE) {
-            binding.actionButton.isVisible = true
-            binding.actionButton.setOnClickListener {
-                fetchRoute()
-            }
+            // style loaded
+        }
+
+        binding.toggleUnitButton.setOnClickListener {
+            val currentUnit = distanceFormatterOptions.unitType
+            val newUnit = if (currentUnit == UnitType.METRIC) UnitType.IMPERIAL else UnitType.METRIC
+            distanceFormatterOptions = distanceFormatterOptions.toBuilder()
+                .unitType(newUnit)
+                .build()
+            lastLocationMatcherResult?.let { updateSpeedLimit(it) }
         }
     }
 

--- a/app/src/main/java/com/mapbox/navigation/examples/standalone/speedlimit/res/layout/mapbox_activity_show_speed_limit.xml
+++ b/app/src/main/java/com/mapbox/navigation/examples/standalone/speedlimit/res/layout/mapbox_activity_show_speed_limit.xml
@@ -42,4 +42,19 @@
         <!-- Uncomment the following line of code to customize the MapboxManeuverView -->
         <!-- style="@style/MapboxCustomManeuverStyle" -->
     </com.mapbox.navigation.ui.components.speedlimit.view.MapboxSpeedInfoView>
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/toggleUnitButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:background="@drawable/mapbox_button"
+        android:padding="12dp"
+        android:text="Toggle Unit"
+        android:textAllCaps="false"
+        android:textColor="@android:color/white"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:ignore="HardcodedText" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
add a toggle button to show how to change speed limit unit (mph vs kph) in the Render Speed Limit for a route sample. 

Dev.to blog as reference: https://dev.to/mapbox/quick-tip-dynamic-speed-units-in-mapbox-navigation-sdk-for-android-4dm5

<img width="861" height="1920" alt="ezgif com-animated-gif-maker" src="https://github.com/user-attachments/assets/173b095c-d22f-472e-8389-4dda8740e472" />
