### PR TITLE
[NAVAND-7302] Update voice instruction example

### DIFF
--- a/app/src/main/java/com/mapbox/navigation/examples/standalone/voice/PlayVoiceInstructionsActivity.kt
+++ b/app/src/main/java/com/mapbox/navigation/examples/standalone/voice/PlayVoiceInstructionsActivity.kt
@@ -49,7 +49,6 @@ import com.mapbox.navigation.voice.api.MapboxVoiceInstructionsPlayer
 import com.mapbox.navigation.voice.model.SpeechAnnouncement
 import com.mapbox.navigation.voice.model.SpeechError
 import com.mapbox.navigation.voice.model.SpeechValue
-import com.mapbox.navigation.voice.model.SpeechVolume
 import java.util.Date
 import java.util.Locale
 
@@ -263,7 +262,7 @@ class PlayVoiceInstructionsActivity : AppCompatActivity() {
      * when voice instructions should be muted.
      */
     private val voiceInstructionsObserver = VoiceInstructionsObserver { voiceInstructions ->
-        if(!isVoiceInstructionsMuted) {
+        if (!isVoiceInstructionsMuted) {
             speechApi.generate(voiceInstructions, speechCallback)
         }
     }

--- a/app/src/main/java/com/mapbox/navigation/examples/standalone/voice/PlayVoiceInstructionsActivity.kt
+++ b/app/src/main/java/com/mapbox/navigation/examples/standalone/voice/PlayVoiceInstructionsActivity.kt
@@ -135,17 +135,15 @@ class PlayVoiceInstructionsActivity : AppCompatActivity() {
     private lateinit var voiceInstructionsPlayer: MapboxVoiceInstructionsPlayer
 
     /**
-     * Stores and updates the state of whether the voice instructions should be played as they come or muted.
+     * Stores and updates the state of whether the voice instructions should be played.
      */
     private var isVoiceInstructionsMuted = false
         set(value) {
             field = value
             if (value) {
                 binding.soundButton.muteAndExtend(1500L)
-                voiceInstructionsPlayer.volume(SpeechVolume(0f))
             } else {
                 binding.soundButton.unmuteAndExtend(1500L)
-                voiceInstructionsPlayer.volume(SpeechVolume(1f))
             }
         }
 
@@ -260,9 +258,14 @@ class PlayVoiceInstructionsActivity : AppCompatActivity() {
 
     /**
      * Observes when a new voice instruction should be played.
+     *
+     * Playback is gated by `isVoiceInstructionsMuted` to avoid acquiring audio focus
+     * when voice instructions should be muted.
      */
     private val voiceInstructionsObserver = VoiceInstructionsObserver { voiceInstructions ->
-        speechApi.generate(voiceInstructions, speechCallback)
+        if(!isVoiceInstructionsMuted) {
+            speechApi.generate(voiceInstructions, speechCallback)
+        }
     }
 
     private val mapboxNavigation: MapboxNavigation by requireMapboxNavigation(


### PR DESCRIPTION
Issue
---------

Voice example is not showing properly how to mute voice instructions. 
Currently example shows muting as setting the player volume to 0 - resulting in the ducking issue. (Instruction is still "played", and it takes audio focus from other applications. 


**Bug:**  After mute  is clicked, music is played with interruptions.
Video with bug example:
[ducking_issue.webm](https://github.com/user-attachments/assets/a4deabe9-6859-4355-9cd9-b473ad504302)



Change
--------

Instead of setting volume, add guard check to prevent generating voice instruction. 

Change verification 
--------

After mute  is clicked, music is played **without** interruption.
Video after change: [after_guard.webm](https://github.com/user-attachments/assets/5632a2bf-9605-4d45-83a2-aa1b4647566e)

